### PR TITLE
Fix/icingadb schema management

### DIFF
--- a/roles/icingadb/tasks/manage_schema_mysql.yml
+++ b/roles/icingadb/tasks/manage_schema_mysql.yml
@@ -16,7 +16,7 @@
       ansible.builtin.shell: >
         {{ mysqlcmd }}
         -Ns -e "select version from icingadb_schema"
-      failed_when: _db_schema.stderr | length > 0
+      failed_when: false
       changed_when: false
       check_mode: false
       register: _db_schema

--- a/roles/icingadb/tasks/manage_schema_pgsql.yml
+++ b/roles/icingadb/tasks/manage_schema_pgsql.yml
@@ -20,7 +20,7 @@
       ansible.builtin.shell: >
         {{ _tmp_pgsqlcmd }}
         -w -c "select version from icingadb_schema"
-      failed_when: _db_schema.stderr | length > 0
+      failed_when: false
       changed_when: false
       check_mode: false
       register: _db_schema


### PR DESCRIPTION
This PR fixes a typo in a variable name and adjusts the `changed_when` logic of the existing schema's lookup.