### PR TITLE
Enhancement/icinga2 zones conf

### DIFF
--- a/plugins/action/icinga2_zones_conf.py
+++ b/plugins/action/icinga2_zones_conf.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+
+# Make coding more python3-ish, this is required for contributions to Ansible
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from datetime import datetime
+from ansible.utils.vars import merge_hash
+
+
+
+def get_sub_hierarchy(hierarchy, name, groups, parent=None):
+    # Traverses a nested dictionary in search of a specific key (name)
+    # If found, returns sub-dictionary as value for key of name "name"
+    # If recursion was needed, result will be a dict with key equal to own parent key
+    # E.g.
+    # dict={ "master": { "europe": { "germany": {
+    #                                  "berlin": None,
+    #                                  "nuremberg": None
+    #                                },
+    #                                "france": {
+    #                                  "paris": None
+    #                                },
+    #                              },
+    #                    "usa": None
+    #                  }
+    #      }
+    # Name="master" -> Returned: {'master': {'europe': {'germany': {'berlin': None, 'nuremberg': None}, 'france': {'paris': None}}, 'usa': None}}
+    # Name="germany" -> Returned: {'europe': {'germany': {'berlin': None, 'nuremberg': None}}}
+
+
+    top_level_keys = list(hierarchy.keys())
+
+    # Check if inventory name or any group name matches top level keys of dictionary
+    for possible_name in [name] + groups:
+        if possible_name in top_level_keys:
+            name = possible_name
+
+    # If name is toplevel key, e.g. master
+    if name in top_level_keys:
+        if parent:
+            # Only return the relevant sub-tree of the hierarchy
+            hierarchy = {parent: {name: hierarchy[name]}}
+        return hierarchy
+
+    # If name is subkey of toplevel key
+    for top_level_key in top_level_keys:
+        sub_hierarchy = hierarchy[top_level_key]
+        if isinstance(sub_hierarchy, dict):
+            new_hierarchy = get_sub_hierarchy(sub_hierarchy, name, groups, top_level_key)
+            if new_hierarchy:
+                return new_hierarchy
+
+    # Return empty dict if name not found anywhere within hierarchy
+    return dict()
+
+
+
+def get_best_host_attr(inventory, name):
+    for host_option in [
+        "ansible_fqdn",
+        "ansible_hostname",
+        "inventory_hostname",
+    ]:
+        if host_option in inventory["hostvars"][name]:
+            return inventory["hostvars"][name][host_option]
+    # Return inventory hostname by default
+    return name
+
+
+
+def get_endpoints_from_zones(zones, name, inventory):
+    # Return emtpy list if no zones are given
+    if not zones:
+        return list()
+
+    endpoints = list()
+
+    own_zone             = [zone for zone in zones if name in zone["endpoints"]][0]
+    own_zone_name        = own_zone["name"]
+    own_parent_zone_name = own_zone["parent"] if "parent" in own_zone else None
+
+    for zone in zones:
+        for endpoint_name in zone["endpoints"]:
+            endpoint = dict()
+            endpoint["name"] = endpoint_name
+
+            # If own parent
+            if zone["name"] == own_parent_zone_name:
+                # If connection to own parent
+                endpoint["host"] = get_best_host_attr(inventory, endpoint_name)
+            elif zone["name"] == own_zone_name and endpoint_name != name:
+                # If connection to HA partner
+                endpoint["host"] = get_best_host_attr(inventory, endpoint_name)
+            elif "parent" in zone and zone["parent"] == own_zone_name:
+                # If connection to direct children
+                endpoint["host"] = get_best_host_attr(inventory, endpoint_name)
+
+            endpoints.append(endpoint)
+
+    return endpoints
+
+
+
+def get_zones_from_hierarchy(hierarchy, groups, parent=None):
+    if not hierarchy:
+        return list()
+
+    zone_list = list()
+    zone_name = list(hierarchy.keys())[0]
+
+    this_zone = dict()
+    this_zone["name"] = zone_name
+
+    if parent:
+        this_zone["parent"] = parent
+
+
+    # get_endpoints(name, inventory, groups)
+    endpoints = list()
+    if zone_name in groups:
+        for host in groups[zone_name]:
+            endpoints.append(host)
+    else:
+        endpoints.append(zone_name)
+
+    this_zone["endpoints"] = endpoints
+    zone_list.append(this_zone)
+
+
+    if isinstance(hierarchy[zone_name], dict):
+        for key, value in hierarchy[zone_name].items():
+            # Recursion step: combine current list (single zone) with each child zone
+            zone_list += get_zones_from_hierarchy({key: value}, groups, parent=zone_name)
+
+    return zone_list
+
+
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp
+
+        module_args = self._task.args.copy()
+        #module_return = self._execute_module(
+        #    module_name="setup",
+        #    module_args=module_args,
+        #    task_vars=task_vars, tmp=tmp
+        #)
+
+        #### Variables needed for processing
+        hierarchy                  = merge_hash(module_args.pop("hierarchy", False), dict())
+        ansible_inventory_hostname = task_vars["inventory_hostname"]
+        ansible_groups             = task_vars["groups"]
+        ansible_host_groups        = list(task_vars["group_names"])
+
+        if "all" in ansible_host_groups:
+            ansible_host_groups.remove("all")
+        if "ungrouped" in ansible_host_groups:
+            ansible_host_groups.remove("ungrouped")
+
+
+        # Get sub portion of the given hierarchy starting at own parent, or self if no parent
+        sub_hierarchy = get_sub_hierarchy(hierarchy, ansible_inventory_hostname, ansible_host_groups)
+
+        # Get all zones this node needs to know (parent and all (sub-)children)
+        icinga2_zones = get_zones_from_hierarchy(sub_hierarchy, ansible_groups)
+
+        # Get all endpoints for each known zone
+        icinga2_endpoints = get_endpoints_from_zones(icinga2_zones, ansible_inventory_hostname, task_vars)
+
+        # TO BE DONE: Global zones
+        # get them from another input instead of hierarchy (e.g. global_zones: ['director-global'])
+        # ...
+
+        # Return results
+        result["icinga2_zones"]     = icinga2_zones
+        result["icinga2_endpoints"] = icinga2_endpoints
+
+        return result

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -22,7 +22,7 @@
 - name: Build zones and endpoints from inventory
   when:
     - icinga2_zone_hierarchy is defined
-  icinga.icinga.icinga2_zones_conf:
+  netways.icinga.icinga2_zones_conf:
     hierarchy: "{{ icinga2_zone_hierarchy | default({}) }}"
     global_zones: "{{ icinga2_global_zones }}"
   register: "_zones_conf"

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -15,6 +15,27 @@
     icinga2_ssl_remote_source: "{{ icinga2_dict_features.api.ssl_remote_source | default(false) }}"
     icinga2_ticket_salt: "{{ icinga2_dict_features.api.ticket_salt | default(omit) }}"
 
+- name: Combine global zones into list
+  ansible.builtin.set_fact:
+    icinga2_global_zones: "{{ (icinga2_global_zones | default([])) + (icinga2_zones | selectattr('global', 'true') | map(attribute='name')) }}"
+
+- name: Build zones and endpoints from inventory
+  when:
+    - icinga2_zone_hierarchy is defined
+  icinga.icinga.icinga2_zones_conf:
+    hierarchy: "{{ icinga2_zone_hierarchy | default({}) }}"
+    global_zones: "{{ icinga2_global_zones }}"
+  register: "_zones_conf"
+
+- name: Overwrite some variables
+  when:
+    - icinga2_zone_hierarchy is defined
+  ansible.builtin.set_fact:
+    icinga2_zones: "{{ _zones_conf.icinga2_zones | default(icinga2_zones) }}"
+    icinga2_endpoints: "{{ _zones_conf.icinga2_endpoints | default(icinga2_endpoints) }}"
+    icinga2_ca_host: "{{ (_zones_conf.icinga2_endpoints | first).host | default('none') }}"
+    icinga2_ca_host_port: "{{ (_zones_conf.icinga2_zones | first).port | default(omit) }}"
+
 - assert:
     that: ((icinga2_ssl_cacert is defined and icinga2_ssl_cert is defined and icinga2_ssl_key is defined) or (icinga2_ssl_cacert is undefined and icinga2_ssl_cert is undefined and icinga2_ssl_key is undefined and icinga2_ca_host is defined))
     fail_msg: ca_host is mandatory or ssl_cacert/cert/key have to be set at the same time

--- a/tests/unittestpy3/test_icinga2_zones_conf.py
+++ b/tests/unittestpy3/test_icinga2_zones_conf.py
@@ -1,0 +1,103 @@
+#!/usr/bin/python3
+
+import sys
+sys.path.insert(0,'plugins/action')
+
+import unittest
+from unittest.mock import patch, Mock, MagicMock, call
+
+import requests
+from requests.exceptions import SSLError, RequestException
+from ansible.parsing.yaml.objects import AnsibleSequence, AnsibleMapping
+
+
+#from icinga2_zones_conf import ActionModule
+from icinga2_zones_conf import get_sub_hierarchy
+from icinga2_zones_conf import get_best_endpoint_attrs
+
+
+class TestActionPlugin(unittest.TestCase):
+    def test_get_sub_hierarchy(self):
+        test_hierarchy = {
+            "master": {
+                "master-child": None,
+                "eu": {
+                    "germany": {
+                        "berlin": None,
+                        "nuremberg": None
+                    },
+                    "france": {
+                        "paris": None,
+                    }
+                },
+                "us": {
+                    "washington": None,
+                }
+            }
+        }
+        test_cases = [
+            # name, groups, expected
+            ( "master",       [], {"master": {"master-child": None, "eu": {"germany": {"berlin": None, "nuremberg": None}, "france": {"paris": None}}, "us": {"washington": None}}} ),
+            ( "master-child", [], {"master": {"master-child": None}} ),
+            ( "eu",           [], {"master": {"eu": {"germany": {"berlin": None, "nuremberg": None}, "france": {"paris": None}}}} ),
+            ( "us",           [], {"master": {"us": {"washington": None}}} ),
+            ( "germany",      [], {"eu": {"germany": {"berlin": None, "nuremberg": None}}} ),
+            ( "berlin",       [], {"germany": {"berlin": None}} ),
+            ( "nuremberg",    [], {"germany": {"nuremberg": None}} ),
+            ( "washington",   [], {"us": {"washington": None}} ),
+
+            ( "master1",   ["some-ansible-group", "master"], {"master": {"master-child": None, "eu": {"germany": {"berlin": None, "nuremberg": None}, "france": {"paris": None}}, "us": {"washington": None}}} ),
+            ( "master2",   ["master"],                       {"master": {"master-child": None, "eu": {"germany": {"berlin": None, "nuremberg": None}, "france": {"paris": None}}, "us": {"washington": None}}} ),
+            ( "sat-ger-1", ["germany"],                      {"eu": {"germany": {"berlin": None, "nuremberg": None}}} ),
+            ( "sat-ger-2", ["germany"],                      {"eu": {"germany": {"berlin": None, "nuremberg": None}}} ),
+            ( "sat-ber-1", ["berlin"],                       {"germany": {"berlin": None}} ),
+
+            ( "not-found", [],                               {} ),
+
+        ]
+
+        for name, groups, expected in test_cases:
+            self.assertEqual(get_sub_hierarchy(test_hierarchy, name, groups), expected)
+
+
+    def test_get_best_endpoint_attrs(self):
+        test_inventory = {
+            "hostvars": {
+                "host1": {
+                    "inventory_hostname": "host1",
+                    "ansible_host": "192.168.122.10",
+                    "custom_host_var1": "10.0.1.10",
+                    "custom_host_var2": "10.0.2.10",
+                },
+                "host2": {
+                    "inventory_hostname": "host2",
+                    "ansible_host": "192.168.122.20",
+                    "custom_host_var1": "10.0.1.20",
+                    "custom_port_var": "6556",
+                },
+            }
+        }
+        test_cases = [
+            # name, host_options, port_variable, expected
+            ( "host1", [],                                       None,              {"host": "192.168.122.10", "port": "5665"} ),
+            ( "host1", ["custom_host_var1", "custom_host_var2"], None,              {"host": "10.0.1.10", "port": "5665"} ),
+            ( "host1", ["custom_host_var2", "custom_host_var1"], None,              {"host": "10.0.2.10", "port": "5665"} ),
+            ( "host1", ["var_does_not_exist"],                   None,              {"host": "192.168.122.10", "port": "5665"} ),
+            ( "host1", [],                                       "custom_port_var", {"host": "192.168.122.10", "port": "5665"} ),
+
+            ( "host2", [],                                       None,              {"host": "192.168.122.20", "port": "5665"} ),
+            ( "host2", ["custom_host_var1", "custom_host_var2"], None,              {"host": "10.0.1.20", "port": "5665"} ),
+            ( "host2", ["custom_host_var2", "custom_host_var1"], None,              {"host": "10.0.1.20", "port": "5665"} ),
+            ( "host2", [],                                       "custom_port_var", {"host": "192.168.122.20", "port": "6556"} ),
+
+        ]
+
+        for name, host_options, port_variable, expected in test_cases:
+            self.assertEqual(get_best_endpoint_attrs(test_inventory, name, host_options, port_variable), expected)
+
+
+
+## WIP
+#def test_get_best_endpoint_attrs(inventory, name, host_options=list(), port_variable=None)
+#def test_get_endpoints_from_zones(zones, name, inventory, upper_host_options=list(), middle_host_options=list(), lower_host_options=list(), port_variable=None)
+#def test_get_zones_from_hierarchy(hierarchy, groups, parent=None)


### PR DESCRIPTION
This is currently still work in progress.

This PR will introduce a simple variable (nested dictionary) to define the zone hierarchy.

The corresponding action plugin creates the zones and endpoints for each host according to the variable.  
Each host will only know those zones and endpoints it **has to know**.

Example:

```yaml
icinga2_zones_conf:
  hierarchy:
    master: # Could be inventory_hostname or Ansible group name
      germany:
        berlin1:
        berlin2:
      france:
        paris:
```

From this, the plugin will create zones and endpoints based on available variables.  
It only returns information. Using the information is still up to the role!

---

### Feedback

There is still a need for a proper way to define variables which will be used for the endpoints `host` attribute.

2 hosts could have the same parent but in different networks (2 firewall zones for example).  
We must be able to provide some kind of mapping to tell a given host the correct address when it wants to access its parent.

- Master A
- Satellite B in firewall zone 1
- Satellite C in firewall zone 2

If B wants to access A, it needs IP-1.
If C wants to access A, it needs IP-2.

This mapping must be defined somewhere.

As a fallback, we can always use `inventory_hostname`.