### PR TITLE
Add setting for clients certificate

### DIFF
--- a/changelogs/fragments/379-tls-auth-clients.yml
+++ b/changelogs/fragments/379-tls-auth-clients.yml
@@ -1,0 +1,4 @@
+---
+
+minor_changes:
+  - "Add variable :code:`icingadb_redis_client_certificate` to define whether TLS client certificates are accepted/required/rejected when connecting to the Redis server. Only has an effect when using TLS encryption." 

--- a/roles/icingadb/templates/icingadb.ini.j2
+++ b/roles/icingadb/templates/icingadb.ini.j2
@@ -30,7 +30,7 @@ database:
 
 redis:
   host: {{ icingadb_redis_host }}
-{% if icingadb_redis_tls %}
+{% if icingadb_redis_tls is defiend %}
   port: 0
   tls-port: {{ icingadb_redis_tls_port | default(6380) }}
 {% elif icingadb_redis_port is defined %}

--- a/roles/icingadb/templates/icingadb.ini.j2
+++ b/roles/icingadb/templates/icingadb.ini.j2
@@ -30,7 +30,10 @@ database:
 
 redis:
   host: {{ icingadb_redis_host }}
-{% if icingadb_redis_port is defined %}
+{% if icingadb_redis_tls %}
+  port: 0
+  tls-port: {{ icingadb_redis_tls_port | default(6380) }}
+{% elif icingadb_redis_port is defined %}
   port: {{ icingadb_redis_port }}
 {% endif %}
 {% if icingadb_redis_password is defined %}

--- a/roles/icingadb/templates/icingadb.ini.j2
+++ b/roles/icingadb/templates/icingadb.ini.j2
@@ -30,7 +30,7 @@ database:
 
 redis:
   host: {{ icingadb_redis_host }}
-{% if icingadb_redis_tls is defiend %}
+{% if icingadb_redis_tls is defined %}
   port: 0
   tls-port: {{ icingadb_redis_tls_port | default(6380) }}
 {% elif icingadb_redis_port is defined %}

--- a/roles/icingadb_redis/defaults/main.yml
+++ b/roles/icingadb_redis/defaults/main.yml
@@ -65,4 +65,4 @@ icingadb_redis_rdb_save_incremental_fsync: 'yes'
 #icingadb_redis_tls_cert: /etc/ssl/certs/host.crt
 #icingadb_redis_tls_key: /etc/ssl/private/host.key
 #icingadb_redis_tls_ca: /etc/ssl/certs/root-ca.crt
-#icingadb_redis_client_certificate:
+icingadb_redis_client_certificate: "yes"

--- a/roles/icingadb_redis/defaults/main.yml
+++ b/roles/icingadb_redis/defaults/main.yml
@@ -65,3 +65,4 @@ icingadb_redis_rdb_save_incremental_fsync: 'yes'
 #icingadb_redis_tls_cert: /etc/ssl/certs/host.crt
 #icingadb_redis_tls_key: /etc/ssl/private/host.key
 #icingadb_redis_tls_ca: /etc/ssl/certs/root-ca.crt
+#icingadb_redis_client_certificate:

--- a/roles/icingadb_redis/templates/icingadb-redis.conf.j2
+++ b/roles/icingadb_redis/templates/icingadb-redis.conf.j2
@@ -227,4 +227,5 @@ rdb-save-incremental-fsync {{ icingadb_redis_rdb_save_incremental_fsync }}
 tls-cert-file {{ icingadb_redis_tls_cert }}
 tls-key-file {{ icingadb_redis_tls_key }}
 tls-ca-cert-file {{ icingadb_redis_tls_ca }}
+tls-auth-clients {{ icingadb_redis_client_certificate }}
 {% endif %}


### PR DESCRIPTION
* Client certificate verification should be configurable to allow for more flexibility.
* If communication with Redis should happen exclusively over TLS, the icingadb_redis_port variable must be set to "0". However, doing so will result in a misconfiguration in the Icinga DB Redis section, as the Redis port will also be set to 0.

ref/NC/858268