### PR TITLE
Add labels to loops

### DIFF
--- a/roles/icinga2/tasks/configure.yml
+++ b/roles/icinga2/tasks/configure.yml
@@ -3,6 +3,8 @@
   set_fact:
     icinga2_dict_features: "{{ icinga2_dict_features|default({}) | combine({ item.name: item }) }}"
   with_items: "{{ icinga2_features }}"
+  loop_control:
+    label: "{{ item.name }}"
 
 - name: main config file {{ icinga2_config_path + '/icinga2.conf' }}
   template:
@@ -60,6 +62,8 @@
     state: absent
     dest: "{{ item.path }}"
   loop: "{{ result_frag.files }}"
+  loop_control:
+    label: "{{ item.path }}"
   when:
     - item.path not in icinga2_local_objects
     - item.path not in _icinga2_custom_conf_paths
@@ -94,6 +98,8 @@
     group: "{{ icinga2_group }}"
     mode: 0644
   loop: "{{ result.files }}"
+  loop_control:
+    label: "{{ item.path }}"
   notify: check-and-reload-icinga2-service
 
 - name: enable features
@@ -102,6 +108,8 @@
     path: "{{ '/etc/icinga2/features-enabled/' + icinga2_feature_realname[item.name]|default(item.name) + '.conf' }}"
     src: "{{ '../features-available/' + icinga2_feature_realname[item.name]|default(item.name) + '.conf' if (item.state is undefined or item.state != 'absent') else omit }}"
   loop: "{{ icinga2_features }}"
+  loop_control:
+    label: "{{ item.name }}"
   notify: check-and-reload-icinga2-service
 
 - name: remove empty config files

--- a/roles/icinga2/tasks/features.yml
+++ b/roles/icinga2/tasks/features.yml
@@ -12,6 +12,8 @@
   set_fact:
     features_enabled: "{{ features_enabled|default([]) + [ icinga2_feature_realname[item.path| basename| splitext| first]| default(item.path| basename| splitext| first) ] }}"
   loop: "{{ icinga2_collected_features.files }}"
+  loop_control:
+    label: "{{ item.path }}"
   when: icinga2_purge_features
 
 - name: purge features
@@ -25,3 +27,5 @@
 - name: configure features
   include_tasks: "features/{{ item.name }}.yml"
   loop: "{{ icinga2_features }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -52,6 +52,7 @@
   loop: "{{ result.results }}"
   loop_control:
     loop_var: idx
+    label: "Add '{{ idx.path }}' to local objects"
 
 - name: feature api Zone objects
   icinga2_object:
@@ -67,6 +68,7 @@
   loop: "{{ result.results }}"
   loop_control:
     loop_var: idx
+    label: "Add '{{ idx.path }}' to local objects"
 
 - name: create new CA
   block:

--- a/roles/icinga2/tasks/objects.yml
+++ b/roles/icinga2/tasks/objects.yml
@@ -26,12 +26,16 @@
 - icinga2_object:
     args: "{{ item }}"
   with_items: "{{ tmp_objects }}"
+  loop_control:
+    label: "{{ item.type }} '{{ item.name }}'"
   when: tmp_objects is defined
   register: result
 
 - set_fact:
     icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [item.dest] }}"
   with_items: "{{ result.results }}"
+  loop_control:
+    label: "{{ item.dest }}"
   when: result.results is defined
 
 - name: prepare custom config

--- a/roles/icingaweb2/tasks/main.yml
+++ b/roles/icingaweb2/tasks/main.yml
@@ -15,6 +15,8 @@
 - name: Check each icingaweb2_modules key against known modules
   when: not icingaweb2_ignore_unknown_modules
   loop: "{{ icingaweb2_modules | default({}) | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
   ansible.builtin.assert:
     that:
       - item.key in icingaweb2_module_packages.keys()
@@ -24,6 +26,8 @@
   ansible.builtin.set_fact:
     icingaweb2_packages: "{{ icingaweb2_packages + [ icingaweb2_module_packages[item.key] ] }}"
   loop: "{{ icingaweb2_modules | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
   when: icingaweb2_modules is defined and icingaweb2_module_packages[item.key] is defined and item.value.enabled | bool == true and item.value.source == "package"
   no_log: true
 
@@ -66,6 +70,8 @@
     - icingaweb2_modules is defined
     - item.key in icingaweb2_module_packages.keys()
   loop: "{{ icingaweb2_modules | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
 
 # Many daemons fail before e.g. the resource is set up or the schema hasn't been migrated. This is a workaround.
 - name: Manage enabled module daemons
@@ -74,3 +80,5 @@
     state: restarted
   when: icingaweb2_modules is defined and item.value.enabled|default(false)|bool == true and item.key in ['vspheredb', 'x509']
   loop: "{{ icingaweb2_modules | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"

--- a/roles/icingaweb2/tasks/manage_icingaweb_db.yml
+++ b/roles/icingaweb2/tasks/manage_icingaweb_db.yml
@@ -24,4 +24,5 @@
   loop: "{{ icingaweb2_users }}"
   loop_control:
     loop_var: _current_user
+    label: "{{ _current_user.username }}"
   when: icingaweb2_users | length > 0


### PR DESCRIPTION
Add some labels to loops to not print secrets when running Ansible without verbosity.
Some labels now also remove clutter from the output.