### PR TITLE
Add option for remote certificates in API feature

### DIFF
--- a/changelogs/fragments/382-fix-remote-certificates.yml
+++ b/changelogs/fragments/382-fix-remote-certificates.yml
@@ -1,0 +1,7 @@
+minor_changes:
+  - |
+    The Icinga2 API feature now allows for the use of certificates already present on the remote host.
+    This means that certificates (and the key) no longer have to be present on the Ansible controller
+    which allows for more flexibility when it comes to certificate deployment.
+    The new behavior can be activated by setting :code:`ssl_remote_source: true` within the API feature.
+  - For Icinga2 certificates and key file permissions are now set explicitly when using self generated certificates (**0644** and **0600** respectively).

--- a/doc/role-icinga2/features/feature-api.md
+++ b/doc/role-icinga2/features/feature-api.md
@@ -135,13 +135,17 @@ The role will copy the files from your Ansible controller node to
 **/var/lib/icinga2/certs** on the remote host. File names are
 set to by the parameter `cert_name` (by default FQDN).
 
+If the certificates and the key are already present on the remote host,
+you can set `ssl_remote_source: true` to change the above behavior.
+
 ```yaml
 icinga2_features:
   - name: api
     cert_name: host.example.org
-    ssl_ca: /home/ansible/certs/ca.crt
+    ssl_cacert: /home/ansible/certs/ca.crt
     ssl_cert: /home/ansible/certs/host.crt
     ssl_key: /home/ansible/certs/host.key
+    ssl_remote_source: false
     endpoints:
       - name: NodeName
     zones:
@@ -161,7 +165,7 @@ icinga2_features:
 * `cert_name: string`
   * Common name of Icinga client/server instance. Default is **ansible_fqdn**.
 
-* `ssl_ca: string`
+* `ssl_cacert: string`
   * Path to the ca file when using manual certificates
 
 * `ssl_cert: string`
@@ -169,6 +173,9 @@ icinga2_features:
 
 * `ssl_key: string`
   * Path to the certificate key file when using manual certificates.
+
+* `ssl_remote_source: boolean`
+  * Whether to copy the certificates and key from the remote host instead of from the Ansible controller.
 
 * `endpoints: list of dicts`
   * Defines endpoints in **zones.conf**, each endpoint is required to have a name and optional a host or port.<br>

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -12,6 +12,7 @@
     icinga2_ssl_cert: "{{ icinga2_dict_features.api.ssl_cert | default(omit) }}"
     icinga2_ssl_cacert: "{{ icinga2_dict_features.api.ssl_cacert | default(omit) }}"
     icinga2_ssl_key: "{{ icinga2_dict_features.api.ssl_key | default(omit) }}"
+    icinga2_ssl_remote_source: "{{ icinga2_dict_features.api.ssl_remote_source | default(false) }}"
     icinga2_ticket_salt: "{{ icinga2_dict_features.api.ticket_salt | default(omit) }}"
 
 - assert:
@@ -22,7 +23,7 @@
 - name: api feature cleanup arguments list
   set_fact:
     args: "{{ args|default({}) | combine({idx.key: idx.value}) }}"
-  when: idx.key not in ['ca_host', 'ca_host_port', 'cert_name', 'ca_fingerprint', 'force_newcert', 'zones', 'endpoints', 'ssl_cacert', 'ssl_key', 'ssl_cert', 'ticket_salt' ]
+  when: idx.key not in ['ca_host', 'ca_host_port', 'cert_name', 'ca_fingerprint', 'force_newcert', 'zones', 'endpoints', 'ssl_cacert', 'ssl_key', 'ssl_cert', 'ssl_remote_source', 'ticket_salt' ]
   loop: "{{ icinga2_dict_features.api |dict2items }}"
   loop_control:
     loop_var: idx
@@ -171,10 +172,13 @@
         _tmp_crt:
           - src: "{{ icinga2_ssl_cacert }}"
             dest: "{{ icinga2_cert_path }}/ca.crt"
+            mode: "0644"
           - src: "{{ icinga2_ssl_key }}"
             dest: "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.key"
+            mode: "0600"
           - src: "{{ icinga2_ssl_cert }}"
             dest: "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.crt"
+            mode: "0644"
 
     - name: Ensure icinga2 certificate directory
       file:
@@ -186,11 +190,12 @@
 
     - name: Copy self generated certificates to icinga2 certificate directory
       copy:
-        remote_src: no
+        remote_src: "{{ icinga2_ssl_remote_source }}"
         src: "{{ _crt.src }}"
         dest: "{{ _crt.dest }}"
         owner: "{{ icinga2_user }}"
         group: "{{ icinga2_group }}"
+        mode: "{{ _crt.mode }}"
       notify: check-and-reload-icinga2-service
       loop: "{{ _tmp_crt }}"
       loop_control:


### PR DESCRIPTION
Certificates and key already present on the remote host can now be used instead of copying them from the Ansible controller over to the remote host.

File permissions are now set explicitly for the certificates and the key.

Fixes #382
Fixes #383