### PR TITLE
Fix redis/icingadb config

### DIFF
--- a/changelogs/fragments/fix_pr_379.yml
+++ b/changelogs/fragments/fix_pr_379.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - |
+    The TLS configuration for Icinga DB / Icinga DB Redis has been faulty. Both configuration templates now render properly based on the given TLS related variables.
+    If using TLS in Icinga DB Redis, the non-TLS port will be disabled. The Icinga DB (daemon) configuration now uses the correct YAML key for both the TLS port and the non-TLS port.

--- a/roles/icingadb/templates/icingadb.ini.j2
+++ b/roles/icingadb/templates/icingadb.ini.j2
@@ -31,9 +31,8 @@ database:
 redis:
   host: {{ icingadb_redis_host }}
 {% if icingadb_redis_tls is defined %}
-  port: 0
-  tls-port: {{ icingadb_redis_tls_port | default(6380) }}
-{% elif icingadb_redis_port is defined %}
+  port: {{ icingadb_redis_tls_port | default(icingadb_redis_port) }}
+{% else %}
   port: {{ icingadb_redis_port }}
 {% endif %}
 {% if icingadb_redis_password is defined %}

--- a/roles/icingadb_redis/templates/icingadb-redis.conf.j2
+++ b/roles/icingadb_redis/templates/icingadb-redis.conf.j2
@@ -6,9 +6,11 @@ bind {% for host in icingadb_redis_binds %}
 {% endfor %}
 
 protected-mode {{ icingadb_redis_protected_mode | string }}
-port {{ icingadb_redis_port }}
-{% if icingadb_redis_tls_port is defined %}
-tls-port {{ icingadb_redis_tls_port }}
+{% if icingadb_redis_tls is defined %}
+port: 0
+tls-port: {{ icingadb_redis_tls_port | default(icingadb_redis_port) }}
+{% else %}
+port: {{ icingadb_redis_port }}
 {% endif %}
 tcp-backlog {{ icingadb_redis_tcp_backlog }}
 timeout {{ icingadb_redis_timeout }}

--- a/roles/icingadb_redis/templates/icingadb-redis.conf.j2
+++ b/roles/icingadb_redis/templates/icingadb-redis.conf.j2
@@ -6,11 +6,11 @@ bind {% for host in icingadb_redis_binds %}
 {% endfor %}
 
 protected-mode {{ icingadb_redis_protected_mode | string }}
-{% if icingadb_redis_tls is defined %}
-port: 0
-tls-port: {{ icingadb_redis_tls_port | default(icingadb_redis_port) }}
+{% if icingadb_redis_tls | default(false) %}
+port 0
+tls-port {{ icingadb_redis_tls_port | default(icingadb_redis_port) }}
 {% else %}
-port: {{ icingadb_redis_port }}
+port {{ icingadb_redis_port }}
 {% endif %}
 tcp-backlog {{ icingadb_redis_tcp_backlog }}
 timeout {{ icingadb_redis_timeout }}


### PR DESCRIPTION
In this PR we fix the misconfiguration in icingadb role, icingadb hasn't the  "tls-port" flag. It should be placed in icingadb-redis configuration.