### PR TITLE
Change run_once to throttle to allow independent databases

### DIFF
--- a/changelogs/fragments/fix-runonce-serial.yml
+++ b/changelogs/fragments/fix-runonce-serial.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - |
+    Switch from :code:`run_once` which was used to ensure it runs only once in a cluster resulting in propagated the databases only on the first node even if nodes are independent to :code:`throttle`.
+    This was also fixed for some cases where :code:`run_once` was missing in the current state.

--- a/roles/icinga_kubernetes/tasks/manage_schema_mysql.yml
+++ b/roles/icinga_kubernetes/tasks/manage_schema_mysql.yml
@@ -18,10 +18,11 @@
       ansible.builtin.shell: >
         {{ mysqlcmd }}
         -Ns -e "select version from kubernetes_schema" ||
-        {{ mysqlcmd }}
-        < {{ icinga_kubernetes_database_schema }} &&
-        echo "Schema imported"
+        (
+          {{ mysqlcmd }} < {{ icinga_kubernetes_database_schema }} &&
+          echo "Schema imported"
+        )
       register: _icingakubernetes_schema
       changed_when:
-        - _icingakubernetes_schema.stdout == "Schema imported"
+        - '"Schema imported" in _icingakubernetes_schema.stdout_lines'
       throttle: 1

--- a/roles/icinga_kubernetes/tasks/manage_schema_pgsql.yml
+++ b/roles/icinga_kubernetes/tasks/manage_schema_pgsql.yml
@@ -23,10 +23,12 @@
 #       ansible.builtin.shell: >
 #         {{ _tmp_pgsqlcmd }}
 #         -w -c "select version from kubernetes_schema" ||
-#         {{ _tmp_pgsqlcmd }}
-#         -w -f {{ icinga_kubernetes_database_schema }} &&
-#         echo "Schema imported"
+#         (
+#           {{ _tmp_pgsqlcmd }}
+#           -w -f {{ icinga_kubernetes_database_schema }} &&
+#           echo "Schema imported"
+#         )
 #       register: _icingakubernetes_schema
 #       changed_when:
-#         - _icingakubernetes_schema.stdout == "Schema imported"
+#         - '"Schema imported" in _icingakubernetes_schema.stdout_lines'
 #       throttle: 1

--- a/roles/icingadb/tasks/manage_schema_mysql.yml
+++ b/roles/icingadb/tasks/manage_schema_mysql.yml
@@ -18,10 +18,11 @@
       ansible.builtin.shell: >
         {{ mysqlcmd }}
         -Ns -e "select version from icingadb_schema" ||
-        {{ mysqlcmd }}
-        < {{ icingadb_database_schema }} &&
-        echo "Schema imported"
+        (
+          {{ mysqlcmd }} < {{ icingadb_database_schema }} &&
+          echo "Schema imported"
+        )
       register: _icingadb_schema
       changed_when:
-        - _icingadb_schema.stdout == "Schema imported"
+        - '"Schema imported" in _icingadb_schema.stdout_lines'
       throttle: 1

--- a/roles/icingadb/tasks/manage_schema_pgsql.yml
+++ b/roles/icingadb/tasks/manage_schema_pgsql.yml
@@ -21,10 +21,11 @@
       ansible.builtin.shell: >
         {{ _tmp_pgsqlcmd }}
         -w -c "select version from icingadb_schema" ||
-        {{ _tmp_pgsqlcmd }}
-        -w -f {{ icingadb_database_schema }} &&
-        echo "Schema imported"
+        (
+          {{ _tmp_pgsqlcmd }} -w -f {{ icingadb_database_schema }} &&
+          echo "Schema imported"
+        )
       register: _icingadb_schema
       changed_when:
-        - _icingadb_schema.stdout == "Schema imported"
+        - '"Schema imported" in _icingadb_schema.stdout_lines'
       throttle: 1

--- a/roles/icingaweb2/handlers/main.yml
+++ b/roles/icingaweb2/handlers/main.yml
@@ -1,11 +1,19 @@
 ---
 
-- name: Module Director | Apply pending migrations
-  ansible.builtin.command:
-    cmd: icingacli director migration run
+- name: Module Director | Apply pending migrations # noqa: command-instead-of-shell
+  ansible.builtin.shell:
+    cmd: icingacli director migration pending && icingacli director migration run || echo "No changes"
+  throttle: 1
   listen: "run_director_migrations"
+  register: _tmp_director_migration
+  changed_when: 'not "No changes" in _tmp_director_migration.stdout_lines'
+  failed_when: _tmp_director_migration.stderr_lines | length > 0
 
-- name: Module Director | Run kickstart if required
-  ansible.builtin.command:
-    cmd: icingacli director kickstart run
+- name: Module Director | Run kickstart if required # noqa: command-instead-of-shell
+  ansible.builtin.shell:
+    cmd: icingacli director kickstart required && icingacli director kickstart run || echo "No changes"
+  throttle: 1
   listen: "run_director_kickstart"
+  register: _tmp_director_kickstart
+  changed_when: 'not "No changes" in _tmp_director_kickstart.stdout_lines'
+  failed_when: _tmp_director_kickstart.stderr_lines | length > 0 or "Kickstart has not been configured" in _tmp_director_kickstart.stdout_lines

--- a/roles/icingaweb2/tasks/modules/manage_mysql_imports.yml
+++ b/roles/icingaweb2/tasks/modules/manage_mysql_imports.yml
@@ -25,10 +25,11 @@
   ansible.builtin.shell: >
     {{ _tmp_mysqlcmd }}
     -Ns -e "{{ _db['select_query'] }}" ||
-    {{ _tmp_mysqlcmd }}
-    < {{ _db['schema_path_mysql'] }} &&
-    echo "Schema imported"
+    (
+      {{ _tmp_mysqlcmd }} < {{ _db['schema_path_mysql'] }} &&
+      echo "Schema imported"
+    )
   register: _icingaweb2_schema
   changed_when:
-    - _icingaweb2_schema.stdout == "Schema imported"
+    - '"Schema imported" in _icingaweb2_schema.stdout_lines'
   throttle: 1

--- a/roles/icingaweb2/tasks/modules/manage_pgsql_imports.yml
+++ b/roles/icingaweb2/tasks/modules/manage_pgsql_imports.yml
@@ -24,10 +24,11 @@
   ansible.builtin.shell: >
     {{ _tmp_pgsqlcmd }}
     -tq -c "{{ _db['select_query'] }}" ||
-    {{ _tmp_pgsqlcmd }}
-    < {{ _db['schema_path_pgsql'] }} &&
-    echo "Schema imported"
+    (
+      {{ _tmp_pgsqlcmd }} < {{ _db['schema_path_pgsql'] }} &&
+      echo "Schema imported"
+    )
   register: _icingaweb2_schema
   changed_when:
-    - _icingaweb2_schema.stdout == "Schema imported"
+    - '"Schema imported" in _icingaweb2_schema.stdout_lines'
   throttle: 1

--- a/roles/icingaweb2/tasks/mysql/import_db.yml
+++ b/roles/icingaweb2/tasks/mysql/import_db.yml
@@ -3,14 +3,13 @@
 - name: MySQL check for icingaweb db schema
   ansible.builtin.shell: >
     {{ _tmp_mysqlcmd }}
-    -Ns -e "select * from icingaweb_user"
-  failed_when: false
-  changed_when: false
-  check_mode: false
-  register: _icingaweb2_db_schema
+    -Ns -e "select * from icingaweb_user" ||
+    (
+      {{ _tmp_mysqlcmd }} < /usr/share/icingaweb2/schema/mysql.schema.sql &&
+      echo "Schema imported"
+    )
+  register: _icingaweb_schema
+  changed_when:
+    - '"Schema imported" in _icingaweb_schema.stdout_lines'
+  throttle: 1
 
-- name: MySQL import icingaweb db schema
-  ansible.builtin.shell: >
-    {{ _tmp_mysqlcmd }}
-    < /usr/share/icingaweb2/schema/mysql.schema.sql
-  when: _icingaweb2_db_schema.rc != 0

--- a/roles/icingaweb2/tasks/mysql/users_db.yml
+++ b/roles/icingaweb2/tasks/mysql/users_db.yml
@@ -4,14 +4,16 @@
     {{ _tmp_mysqlcmd }}
     -Ns -e "select name from icingaweb_user where name like '{{ _current_user.username }}'"
     | grep '{{ _current_user.username }}' ||
-    echo "INSERT INTO icingaweb_user (name, active, password_hash) VALUES ('{{ _current_user.username }}', 1,
-    '"`php -r 'echo password_hash("{{ _current_user.password }}", PASSWORD_DEFAULT);'`"')
-    ON DUPLICATE KEY UPDATE active = 1, password_hash = '"`php -r 'echo password_hash("{{ _current_user.password }}", PASSWORD_DEFAULT);'`"'" |  {{ _tmp_mysqlcmd }} -Ns &&
-    echo "User created"
+    (
+      echo "INSERT INTO icingaweb_user (name, active, password_hash) VALUES ('{{ _current_user.username }}', 1,
+      '"`php -r 'echo password_hash("{{ _current_user.password }}", PASSWORD_DEFAULT);'`"')
+      ON DUPLICATE KEY UPDATE active = 1, password_hash = '"`php -r 'echo password_hash("{{ _current_user.password }}", PASSWORD_DEFAULT);'`"'" |  {{ _tmp_mysqlcmd }} -Ns &&
+      echo "User created"
+    )
   register: _icingaweb2_db_user
-  when: _current_user.recreate is false
+  when: (_current_user.recreate | default(false)) is false
   changed_when:
-    - _icingaweb2_db_user.stdout == "User created"
+    - '"User created" in _icingaweb2_db_user.stdout_lines'
   throttle: 1
 
 - name: MySQL recreate Icinga Web 2 user
@@ -19,5 +21,5 @@
     echo "INSERT INTO icingaweb_user (name, active, password_hash) VALUES ('{{ _current_user.username }}', 1,
     '"`php -r 'echo password_hash("{{ _current_user.password }}", PASSWORD_DEFAULT);'`"')
     ON DUPLICATE KEY UPDATE active = 1, password_hash = '"`php -r 'echo password_hash("{{ _current_user.password }}", PASSWORD_DEFAULT);'`"'" |  {{ _tmp_mysqlcmd }} -Ns
-  when: _current_user.recreate is true
+  when: (_current_user.recreate | default(false)) is true
   throttle: 1

--- a/roles/icingaweb2/tasks/pgsql/import_db.yml
+++ b/roles/icingaweb2/tasks/pgsql/import_db.yml
@@ -3,15 +3,13 @@
 - name: PostgreSQL check for icingaweb db schema
   ansible.builtin.shell: >
     {{ _tmp_pgsqlcmd }}
-    -w -c "select * from icingaweb_user"
-  failed_when: false
-  changed_when: false
-  check_mode: false
-  register: _icingaweb2_db_schema
+    -w -c "select * from icingaweb_user" ||
+    (
+      {{ _tmp_pgsqlcmd }} -w -f /usr/share/icingaweb2/schema/pgsql.schema.sql &&
+      echo "Schema imported"
+    )
+  register: _icingaweb_schema
+  changed_when:
+    - '"Schema imported" in _icingaweb_schema.stdout_lines'
+  throttle: 1
 
-- name: PostgreSQL import icingaweb db schema
-  ansible.builtin.shell: >
-    {{ _tmp_pgsqlcmd }}
-    -w -f /usr/share/icingaweb2/schema/pgsql.schema.sql
-  when:
-    - _icingaweb2_db_schema.rc != 0

--- a/roles/icingaweb2/tasks/pgsql/users_db.yml
+++ b/roles/icingaweb2/tasks/pgsql/users_db.yml
@@ -5,15 +5,17 @@
     {{ _tmp_pgsqlcmd }}
     -w -c "select name from icingaweb_user where name like '{{ _current_user.username }}'"
     | grep '{{ _current_user.username }}' ||
-    echo "INSERT INTO icingaweb_user (name, active, password_hash) VALUES ('{{ _current_user.username }}', 1,
-    '"`php -r 'echo password_hash("{{ _current_user.password }}", PASSWORD_DEFAULT);'`"')
-    ON CONFLICT (name) DO UPDATE
-    SET active = 1, password_hash = '"`php -r 'echo password_hash("{{ _current_user.password }}", PASSWORD_DEFAULT);'`"'" | {{ _tmp_pgsqlcmd }} -w &&
-    echo "User created"
+    (
+      echo "INSERT INTO icingaweb_user (name, active, password_hash) VALUES ('{{ _current_user.username }}', 1,
+      '"`php -r 'echo password_hash("{{ _current_user.password }}", PASSWORD_DEFAULT);'`"')
+      ON CONFLICT (name) DO UPDATE
+      SET active = 1, password_hash = '"`php -r 'echo password_hash("{{ _current_user.password }}", PASSWORD_DEFAULT);'`"'" | {{ _tmp_pgsqlcmd }} -w &&
+      echo "User created"
+    )
   register: _icingaweb2_db_user
   when: _current_user.recreate is false
   changed_when:
-    - _icingaweb2_db_user.stdout == "User created"
+    - '"User created" in _icingaweb2_db_user.stdout_lines'
   throttle: 1
 
 - name: PostgreSQL recreate Icinga Web 2 user


### PR DESCRIPTION
We found our use-case was broken by run_once as we did multiple separate instances as a group instead of a high-available pair of nodes.
Using run_once here results in the databases being propagated only on the first node. The idea behind run_once was very likely to ensure it run only once in a cluster.
The better idea is to serialize these tasks so both use cases work. As serial is only available for plays and throttle in a block only works on task level and not the block as a whole, it was needed to change the tasks itself and then add `throttle: 1` to them.

When testing this I found there was an uncovered case already with the db schema "icingaweb". Here I applied the same fix like with the other cases.

Another uncovered case is the db schema "director" which gets applied via cli commands but this is split into a task and a handler so will require a different, more complicated fix. I am open for ideas how to solve this!