### PR TITLE
added monitoring to icingaweb2_module_packages

### DIFF
--- a/roles/icingaweb2/vars/main.yml
+++ b/roles/icingaweb2/vars/main.yml
@@ -6,3 +6,4 @@ icingaweb2_module_packages:
   x509: icinga-x509
   businessprocess: icinga-businessprocess
   kubernetes: icinga-kubernetes-web
+  monitoring: icingaweb2


### PR DESCRIPTION
...because right now an install of icingaweb2-module-monitoring as stated in the docs would fail with some message like this: 
`    "msg": "'monitoring' is an unknown module. Set 'icingaweb2_ignore_unknown_modules' to 'true' if you want to simply skip unknown modules"`