### PR TITLE
Fix monitoring module's 'config.ini' not being deployed

### DIFF
--- a/changelogs/fragments/fix-missing-config-monitoring-module.yml
+++ b/changelogs/fragments/fix-missing-config-monitoring-module.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixed an issue where the :code:`config.ini` file of the :code:`monitoring` module was not deployed.

--- a/roles/icingaweb2/tasks/modules/monitoring.yml
+++ b/roles/icingaweb2/tasks/modules/monitoring.yml
@@ -17,4 +17,4 @@
     _files:
       - commandtransports
       - backends
-      - security
+      - config


### PR DESCRIPTION
The file name `security` was used before to determine the monitoring module's config file.

`security`, however, is actually a **section** within the `config` file ([upstream doumentation](https://icinga.com/docs/icinga-web/latest/modules/monitoring/doc/03-Configuration/#overview))

`config.ini`:
```ini
[security]
...
```

It is correct in our documentation

https://github.com/NETWAYS/ansible-collection-icinga/blob/c7a40c5bd1a65706a466041665f9d1732dd3b681/doc/role-icingaweb2/module-monitoring.md?plain=1#L25-L27

but wrong in the Ansible code

https://github.com/NETWAYS/ansible-collection-icinga/blob/c7a40c5bd1a65706a466041665f9d1732dd3b681/roles/icingaweb2/tasks/modules/monitoring.yml#L20