### PR TITLE
Fix modules not being installed when disabled

### DIFF
--- a/changelogs/fragments/fix-404-disabled-modules.yml
+++ b/changelogs/fragments/fix-404-disabled-modules.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - |
+    Fix issue where the package for any given Icinga Web 2 module was not installed if that module had set :code:`enabled: false`.
+    Modules are now installed and configured properly even when they are set to be disabled in the end.

--- a/roles/icingaweb2/tasks/main.yml
+++ b/roles/icingaweb2/tasks/main.yml
@@ -28,7 +28,10 @@
   loop: "{{ icingaweb2_modules | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
-  when: icingaweb2_modules is defined and icingaweb2_module_packages[item.key] is defined and item.value.enabled | bool == true and item.value.source == "package"
+  when:
+    - icingaweb2_modules is defined
+    - icingaweb2_module_packages[item.key] is defined
+    - item.value.source == "package"
   no_log: true
 
 - name: Check supported operatingsystems


### PR DESCRIPTION
This allows for the installation of disabled Icinga Web 2 modules.  
They are now installed and configured even if they are to be disabled regardless.

Fixes #404