### PR TITLE
Deduplicate Icinga 2 objects before writing

### DIFF
--- a/changelogs/fragments/386_duplicate_objects.yml
+++ b/changelogs/fragments/386_duplicate_objects.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - In the :code:`icinga2` role objects are collected from different places before writing them to files. Duplicates could occur which was not taken care of. All collected objects are now deduplicated using the :code:`unique` filter right before writing to save some time during execution.

--- a/roles/icinga2/tasks/objects.yml
+++ b/roles/icinga2/tasks/objects.yml
@@ -23,6 +23,10 @@
     - icinga2_objects is not string
     - icinga2_objects is not mapping
 
+- name: Remove duplicate objects from list
+  ansible.builtin.set_fact:
+    tmp_objects: "{{ (tmp_objects | default([])) | unique }}"
+
 - icinga2_object:
     args: "{{ item }}"
   with_items: "{{ tmp_objects }}"


### PR DESCRIPTION
This deduplicates collected Icinga 2 objects before writing them to files in order to save some time during execution.