### PR TITLE
Switch to deb822 format

### DIFF
--- a/changelogs/fragments/fix_410_sources-dot-list.yml
+++ b/changelogs/fragments/fix_410_sources-dot-list.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - The error messages about unsupported operating systems have been tuned. They should now appear if and only if the actual OS is in fact not supported instead of appearing after unrelated task failures.
+  - The deb repositories made available by the :code:`repos` role now use the `deb822 format <https://repolib.readthedocs.io/en/latest/deb822-format.html>`__.
+    This can lead to APT warnings on systems that already have the repositories deployed using the old format (sources.list). To fix this, simply remove the old :code:`icinga.list` file after the repositories have been deployed in the new format.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,6 +4,12 @@
   hosts: all
   vars:
     icingaweb2_modules:
+      businessprocess:
+        enabled: true
+        source: package
+        custom_process_files:
+          - name: test.conf
+            src_path: test.conf
       graphite:
         enabled: true
         source: package
@@ -48,6 +54,7 @@
             host: "127.0.0.1"
       monitoring:
         enabled: false
+        source: package
         backends:
           icinga2_ido_mysql:
             type: ido
@@ -120,13 +127,6 @@
       - zones.d/main/commands
       - zones.d/main/hosts
       - zones.d/main/services
-    icingaweb2_modules:
-      businessprocess:
-        enabled: true
-        source: package
-        custom_process_files:
-          - name: test.conf
-            src_path: test.conf
   collections:
     - netways.icinga
   pre_tasks:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -7,5 +7,6 @@
         name:
           - gpg
           - apt-transport-https
+          - python3-debian
         update_cache: yes
       when: ansible_os_family == "Debian"

--- a/molecule/local-default-pgsql/prepare.yml
+++ b/molecule/local-default-pgsql/prepare.yml
@@ -8,5 +8,6 @@
         name:
           - gpg
           - apt-transport-https
+          - python3-debian
         update_cache: yes
       when: ansible_os_family == "Debian"

--- a/molecule/local-default/prepare.yml
+++ b/molecule/local-default/prepare.yml
@@ -8,5 +8,6 @@
         name:
           - gpg
           - apt-transport-https
+          - python3-debian
         update_cache: yes
       when: ansible_os_family == "Debian"

--- a/molecule/role-icingadb/prepare.yml
+++ b/molecule/role-icingadb/prepare.yml
@@ -7,5 +7,6 @@
         name:
           - gpg
           - apt-transport-https
+          - python3-debian
         update_cache: yes
       when: ansible_os_family == "Debian"

--- a/molecule/role-icingadb_redis/prepare.yml
+++ b/molecule/role-icingadb_redis/prepare.yml
@@ -7,5 +7,6 @@
         name:
           - gpg
           - apt-transport-https
+          - python3-debian
         update_cache: yes
       when: ansible_os_family == "Debian"

--- a/molecule/role-icingaweb2/prepare.yml
+++ b/molecule/role-icingaweb2/prepare.yml
@@ -7,5 +7,6 @@
         name:
           - gpg
           - apt-transport-https
+          - python3-debian
         update_cache: yes
       when: ansible_os_family == "Debian"

--- a/roles/icinga2/tasks/install.yml
+++ b/roles/icinga2/tasks/install.yml
@@ -1,12 +1,18 @@
 ---
 - name: Check supported operatingsystems
+  vars:
+    _paths: "{{ ansible_search_path }}"
+    _file: "install_on_{{ ansible_os_family }}.yml"
+    _tasks_file: "{{ lookup('first_found', paths=_paths, files=_file, skip=true) }}"
   block:
     - name: Install on {{ ansible_os_family }}
+      when: _tasks_file | length > 0
       ansible.builtin.include_tasks: "install_on_{{ ansible_os_family }}.yml"
-  rescue:
+
     - name: "OS family not supported!"
+      when: _tasks_file | length == 0
       ansible.builtin.fail:
-        msg: "The OS {{ ansible_os_family }} is not supported!"
+        msg: "The OS '{{ ansible_os_family }}' is not supported!"
 
 - name: Prepare fragments path
   ansible.builtin.file:

--- a/roles/icinga_kubernetes/tasks/main.yml
+++ b/roles/icinga_kubernetes/tasks/main.yml
@@ -13,13 +13,19 @@
         - "{{ role_path }}/vars"
 
 - name: Check supported operatingsystems
+  vars:
+    _paths: "{{ ansible_search_path }}"
+    _file: "install_on_{{ ansible_os_family | lower }}.yml"
+    _tasks_file: "{{ lookup('first_found', paths=_paths, files=_file, skip=true) }}"
   block:
     - name: Include OS specific installation
+      when: _tasks_file | length > 0
       ansible.builtin.include_tasks: "install_on_{{ ansible_os_family | lower }}.yml"
-  rescue:
+
     - name: "OS family not supported!"
+      when: _tasks_file | length == 0
       ansible.builtin.fail:
-        msg: "The OS {{ ansible_os_family }} is not supported!"
+        msg: "The OS '{{ ansible_os_family }}' is not supported!"
 
 - name: Include Tasks to configure Icinga Kubernetes
   ansible.builtin.include_tasks: manage_config.yml

--- a/roles/icingadb/tasks/main.yml
+++ b/roles/icingadb/tasks/main.yml
@@ -13,13 +13,19 @@
         - "{{ role_path }}/vars"
 
 - name: Check supported operatingsystems 
+  vars:
+    _paths: "{{ ansible_search_path }}"
+    _file: "install_on_{{ ansible_os_family | lower }}.yml"
+    _tasks_file: "{{ lookup('first_found', paths=_paths, files=_file, skip=true) }}"
   block:
     - name: Include OS specific installation
+      when: _tasks_file | length > 0
       ansible.builtin.include_tasks: "install_on_{{ ansible_os_family | lower }}.yml"
-  rescue:
+
     - name: "OS family not supported!"
+      when: _tasks_file | length == 0
       ansible.builtin.fail:
-        msg: "The OS {{ ansible_os_family }} is not supported!"
+        msg: "The OS '{{ ansible_os_family }}' is not supported!"
 
 - name: Include Tasks to configure IcingaDB
   ansible.builtin.include_tasks: manage_config.yml

--- a/roles/icingadb_redis/tasks/main.yml
+++ b/roles/icingadb_redis/tasks/main.yml
@@ -13,13 +13,19 @@
         - "{{ role_path }}/vars"
 
 - name: Check supported operatingsystems
+  vars:
+    _paths: "{{ ansible_search_path }}"
+    _file: "install_on_{{ ansible_os_family | lower }}.yml"
+    _tasks_file: "{{ lookup('first_found', paths=_paths, files=_file, skip=true) }}"
   block:
     - name: Include OS specific installation
+      when: _tasks_file | length > 0
       ansible.builtin.include_tasks: "install_on_{{ ansible_os_family | lower }}.yml"
-  rescue:
+
     - name: "OS family not supported!"
+      when: _tasks_file | length == 0
       ansible.builtin.fail:
-        msg: "The OS {{ ansible_os_family }} is not supported!"
+        msg: "The OS '{{ ansible_os_family }}' is not supported!"
 
 - name: Manage IcingaDB Redis configuration
   ansible.builtin.include_tasks: "manage_config.yml"

--- a/roles/icingaweb2/tasks/main.yml
+++ b/roles/icingaweb2/tasks/main.yml
@@ -35,13 +35,19 @@
   no_log: true
 
 - name: Check supported operatingsystems
+  vars:
+    _paths: "{{ ansible_search_path }}"
+    _file: "install_on_{{ ansible_os_family | lower }}.yml"
+    _tasks_file: "{{ lookup('first_found', paths=_paths, files=_file, skip=true) }}"
   block:
     - name: Include OS specific installation
+      when: _tasks_file | length > 0
       ansible.builtin.include_tasks: "install_on_{{ ansible_os_family | lower }}.yml"
-  rescue:
+
     - name: "OS family not supported!"
+      when: _tasks_file | length == 0
       ansible.builtin.fail:
-        msg: "The OS {{ ansible_os_family }} is not supported!"
+        msg: "The OS '{{ ansible_os_family }}' is not supported!"
 
 - name: Manage Icinga Web 2 config
   ansible.builtin.include_tasks: "manage_icingaweb_config.yml"

--- a/roles/monitoring_plugins/tasks/main.yml
+++ b/roles/monitoring_plugins/tasks/main.yml
@@ -3,13 +3,19 @@
 - gather_facts:
 
 - name: Check supported operatingsystems
+  vars:
+    _paths: "{{ role_path }}/vars"
+    _file: "{{ ansible_os_family }}.yml"
+    _tasks_file: "{{ lookup('first_found', paths=_paths, files=_file, skip=true) }}"
   block:
     - name: Include OS family specific vars
+      when: _tasks_file | length > 0
       ansible.builtin.include_vars: "{{ role_path }}/vars/{{ ansible_os_family }}.yml"
-  rescue:
+
     - name: "OS family not supported!"
+      when: _tasks_file | length == 0
       ansible.builtin.fail:
-        msg: "The OS {{ ansible_os_family }} is not supported!"
+        msg: "The OS '{{ ansible_os_family }}' is not supported!"
 
 - name: Include OS distribution/version specific vars
   include_vars: "{{ lookup('first_found', params) }}"

--- a/roles/repos/defaults/main.yml
+++ b/roles/repos/defaults/main.yml
@@ -17,9 +17,10 @@ icinga_repo_zypper_snapshot_url: "https://packages.icinga.com/openSUSE/$releasev
 
 icinga_repo_apt_key: "{{ icinga_repo_gpgkey }}"
 icinga_repo_apt_keyring: /etc/apt/keyrings/icinga-archive-keyring.asc
-icinga_repo_apt_stable_deb: "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }} main"
-icinga_repo_apt_testing_deb: "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }}-testing main"
-icinga_repo_apt_snapshot_deb: "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }}-snapshots main"
+icinga_repo_apt_url: "http://packages.icinga.com/{{ ansible_distribution | lower }}"
+icinga_repo_apt_stable_deb: "icinga-{{ ansible_distribution_release | lower }}"
+icinga_repo_apt_testing_deb: "icinga-{{ ansible_distribution_release | lower }}-testing"
+icinga_repo_apt_snapshot_deb: "icinga-{{ ansible_distribution_release | lower }}-snapshots"
 
 icinga_repo_gpgkey: "https://packages.icinga.com/icinga.key"
 icinga_repo_stable: true

--- a/roles/repos/tasks/Debian.yml
+++ b/roles/repos/tasks/Debian.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Apt - ensure apt keyrings directory
   ansible.builtin.file:
     state: directory
@@ -16,21 +17,23 @@
     mode: '0644'
     force: true
 
-- name: Apt - add Icinga repository (stable)
-  become: yes
-  apt_repository:
-    filename: /etc/apt/sources.list.d/icinga
-    repo: "{{ icinga_repo_apt_stable_deb }}"
-    state: "{{ 'present' if icinga_repo_stable else 'absent' }}"
-- name: Apt - add Icinga repository (testing)
-  become: yes
-  apt_repository:
-    filename: /etc/apt/sources.list.d/icinga
-    repo: "{{ icinga_repo_apt_testing_deb }}"
-    state: "{{ 'present' if icinga_repo_testing else 'absent' }}"
-- name: Apt - add Icinga repository (snapshot)
-  become: yes
-  apt_repository:
-    filename: /etc/apt/sources.list.d/icinga
-    repo: "{{ icinga_repo_apt_snapshot_deb }}"
-    state: "{{ 'present' if icinga_repo_snapshot else 'absent' }}"
+- name: Apt - add Icinga repository
+  ansible.builtin.deb822_repository:
+    state: present
+    name: icinga
+    types: deb
+    uris: "{{ icinga_repo_apt_url }}"
+    suites: "{{
+      ([icinga_repo_apt_stable_deb]) +
+      ([icinga_repo_apt_testing_deb] if icinga_repo_testing else []) +
+      ([icinga_repo_apt_snapshot_deb] if icinga_repo_snapshot else [])
+    }}"
+    components:
+      - main
+    signed_by: "{{ icinga_repo_apt_keyring }}"
+  register: _apt_repo
+
+- name: Apt - update cache
+  when: _apt_repo.changed
+  ansible.builtin.apt:
+    update_cache: true

--- a/roles/repos/tasks/main.yml
+++ b/roles/repos/tasks/main.yml
@@ -30,10 +30,16 @@
     - icinga_repo_subscription_password is defined
 
 - name: Check OS family
+  vars:
+    _paths: "{{ ansible_search_path }}"
+    _file: "{{ ansible_os_family }}.yml"
+    _tasks_file: "{{ lookup('first_found', paths=_paths, files=_file, skip=true) }}"
   block:
     - name: Add repositories {{ ansible_os_family }}
+      when: _tasks_file | length > 0
       ansible.builtin.include_tasks: "{{ ansible_os_family }}.yml"
-  rescue:
+
     - name: "OS family not supported!"
+      when: _tasks_file | length == 0
       ansible.builtin.fail:
-        msg: "The OS '{{ ansible_os_family }}' isn't currently supported!"
+        msg: "The OS '{{ ansible_os_family }}' is not supported!"


### PR DESCRIPTION
Switch from .list to .sources format for deb repositories.  
Adjust workflows to install python3-debian.  
Fix mistake in workflow that led to fewer Icinga Web 2 modules being tested.