### PR TITLE
Fix merging of 'icinga2_objects'

### DIFF
--- a/roles/icinga2/tasks/configure.yml
+++ b/roles/icinga2/tasks/configure.yml
@@ -78,6 +78,7 @@
   changed_when: _removed_dirs.attempts > 1
 
 - name: Collect config files (icinga2_config_path)
+  when: icinga2_config_directories is defined
   vars:
     _icinga2_config_directories: "{{
       (icinga2_config_directories | select('match', '^conf.d/.*')) +
@@ -96,6 +97,7 @@
   vars:
     _icinga2_sys_config_fragment_path: "{{ item | regex_replace('^' + icinga2_config_path + '(.*)$', icinga2_fragments_path + '\\1') }}"
   when:
+    - icinga2_config_directories is defined
     - _icinga2_sys_config_fragment_path not in icinga2_local_objects
     - _icinga2_sys_config_fragment_path not in _icinga2_custom_conf_paths
   ansible.builtin.file:
@@ -103,6 +105,7 @@
     dest: "{{ item }}"
 
 - name: Remove empty config dirs (icinga2_config_path) # noqa: command-instead-of-shell
+  when: icinga2_config_directories is defined
   vars:
     _icinga2_config_directories: "{{
       (

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -30,7 +30,7 @@
 
 - name: feature api ApiListener object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: api
@@ -40,7 +40,7 @@
 
 - name: feature api Endpoint objects
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - type: Endpoint
@@ -52,7 +52,7 @@
 
 - name: feature api Zone objects
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - type: Zone

--- a/roles/icinga2/tasks/features/checker.yml
+++ b/roles/icinga2/tasks/features/checker.yml
@@ -2,7 +2,7 @@
 
 - name: feature checker CheckerComponent object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: checker

--- a/roles/icinga2/tasks/features/command.yml
+++ b/roles/icinga2/tasks/features/command.yml
@@ -2,7 +2,7 @@
 
 - name: feature command ExternalCommandListener object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: command

--- a/roles/icinga2/tasks/features/compatlog.yml
+++ b/roles/icinga2/tasks/features/compatlog.yml
@@ -2,7 +2,7 @@
 
 - name: Feature compatlog CompatLogger object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: compatlog

--- a/roles/icinga2/tasks/features/debuglog.yml
+++ b/roles/icinga2/tasks/features/debuglog.yml
@@ -2,7 +2,7 @@
 
 - name: feature debuglog FileLogger object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: debug-file

--- a/roles/icinga2/tasks/features/elasticsearch.yml
+++ b/roles/icinga2/tasks/features/elasticsearch.yml
@@ -2,7 +2,7 @@
 
 - name: feature elasticsearch ElasticsearchWriter object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: elasticsearch

--- a/roles/icinga2/tasks/features/gelf.yml
+++ b/roles/icinga2/tasks/features/gelf.yml
@@ -2,7 +2,7 @@
 
 - name: feature influxdb GelfWriter object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: gelf

--- a/roles/icinga2/tasks/features/graphite.yml
+++ b/roles/icinga2/tasks/features/graphite.yml
@@ -2,7 +2,7 @@
 
 - name: feature graphite GraphiteWriter object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: graphite

--- a/roles/icinga2/tasks/features/icingadb.yml
+++ b/roles/icinga2/tasks/features/icingadb.yml
@@ -2,7 +2,7 @@
 
 - name: feature icingadb IcingaDB object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: icingadb

--- a/roles/icinga2/tasks/features/idomysql.yml
+++ b/roles/icinga2/tasks/features/idomysql.yml
@@ -6,7 +6,7 @@
 
 - name: feature idomysql IdoMysqlConnection object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: ido-mysql

--- a/roles/icinga2/tasks/features/idopgsql.yml
+++ b/roles/icinga2/tasks/features/idopgsql.yml
@@ -6,7 +6,7 @@
 
 - name: feature idopgsql IdoPgsqlConnection object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: ido-pgsql

--- a/roles/icinga2/tasks/features/influxdb.yml
+++ b/roles/icinga2/tasks/features/influxdb.yml
@@ -2,7 +2,7 @@
 
 - name: feature influxdb InfluxdbWriter object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: influxdb

--- a/roles/icinga2/tasks/features/influxdb2.yml
+++ b/roles/icinga2/tasks/features/influxdb2.yml
@@ -2,7 +2,7 @@
 
 - name: feature influxdb2 Influxdb2Writer object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: influxdb2

--- a/roles/icinga2/tasks/features/livestatus.yml
+++ b/roles/icinga2/tasks/features/livestatus.yml
@@ -2,7 +2,7 @@
 
 - name: feature livestatus LivestatusListener object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: livestatus

--- a/roles/icinga2/tasks/features/mainlog.yml
+++ b/roles/icinga2/tasks/features/mainlog.yml
@@ -2,7 +2,7 @@
 
 - name: feature mainlog FileLogger object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: main-log

--- a/roles/icinga2/tasks/features/notification.yml
+++ b/roles/icinga2/tasks/features/notification.yml
@@ -2,7 +2,7 @@
 
 - name: feature notification NotificationComponent object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: notification

--- a/roles/icinga2/tasks/features/opentsdb.yml
+++ b/roles/icinga2/tasks/features/opentsdb.yml
@@ -2,7 +2,7 @@
 
 - name: feature influxdb OpenTsdbWriter object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: opentsdb

--- a/roles/icinga2/tasks/features/perfdata.yml
+++ b/roles/icinga2/tasks/features/perfdata.yml
@@ -2,7 +2,7 @@
 
 - name: feature perfdata PerfdataWriter object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: perfdata

--- a/roles/icinga2/tasks/features/syslog.yml
+++ b/roles/icinga2/tasks/features/syslog.yml
@@ -2,7 +2,7 @@
 
 - name: feature syslog SyslogLogger object
   ansible.builtin.set_fact:
-    icinga2_objects: "{{ icinga2_objects + objects }}"
+    tmp_objects: "{{ tmp_objects | default([]) + objects }}"
   vars:
     objects:
       - name: syslog


### PR DESCRIPTION
`icinga2_objects` might be a dict or a list. Merging will happen at a specific point during execution.
Feature objects are now merged with `tmp_objects` to avoid problems.