### PR TITLE
Switch to 'ansible.windows.win_shell' in 'Install-Icinga' task

### DIFF
--- a/changelogs/fragments/fix_ifw_winrm_stuck_idle.yml
+++ b/changelogs/fragments/fix_ifw_winrm_stuck_idle.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "Using :code:`ansible.windows.win_powershell` for the :code:`Install-Icinga` command can sometimes get stuck and stay idle indefinitely.
+    The according task now uses :code:`ansible.windows.win_shell` as this seems to be more reliable."

--- a/roles/ifw/tasks/configure_icinga2.yml
+++ b/roles/ifw/tasks/configure_icinga2.yml
@@ -75,6 +75,16 @@
         src: "/tmp/{{ ifw_icinga2_cn }}.crt"
       register: _icinga2_host_cert
 
+    - name: Remove temporary CSR and CRT
+      become: true
+      delegate_to: "{{ ifw_icinga2_ca_host | default('localhost', true) }}"
+      loop:
+        - "/tmp/{{ ifw_icinga2_cn }}.csr"
+        - "/tmp/{{ ifw_icinga2_cn }}.crt"
+      ansible.builtin.file:
+        state: absent
+        path: "{{ item }}"
+
     - name: Deploy host certificate
       when: not ifw_icinga2_ca_host is none
       ansible.windows.win_copy:
@@ -148,8 +158,4 @@
   async: 300
   poll: 30
   when: _assertion_result.evaluated_to is defined
-  ansible.windows.win_powershell:
-    script: "Install-Icinga -InstallCommand \"{{ _install_command }}\""
-    arguments:
-      - "-ExecutionPolicy"
-      - "ByPass"
+  ansible.windows.win_shell: "Install-Icinga -InstallCommand '{{ _install_command }}'"

--- a/roles/ifw/tasks/install_components.yml
+++ b/roles/ifw/tasks/install_components.yml
@@ -18,7 +18,7 @@
 - name: Validate requested components are installable
   loop: "{{ ifw_components }}"
   ansible.builtin.assert:
-    that: "{{ item.name in (_available_components_json | map(attribute='key') | sort) }}"
+    that: item.name in (_available_components_json | map(attribute='key') | sort)
     fail_msg: "'{{ item.name }}' is not an installable component! (Keep component names lowercase)"
 
 - name: Remove non requested components


### PR DESCRIPTION
Switch to using `ansible.windows.win_shell` for the `Install-Icinga` command since this seems to be more reliable.