### PR TITLE
Adjust to future 'INJECT_FACTS_AS_VARS' behavior

### DIFF
--- a/changelogs/fragments/ansible_facts.yml
+++ b/changelogs/fragments/ansible_facts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Change occurrences of :code:`ansible_<fact_name>` to :code:`ansible_facts["<fact_name>"]` in preparation of :code:`ansible-core=2.24`'s new :code:`INJECT_FACTS_AS_VARS` behavior.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -121,7 +121,7 @@ This is an example on how to install an Icinga 2 server/master instance.
   vars:
     icinga2_constants:  # Set default constants and TicketSalt for the CA
       TicketSalt: "{{ lookup('ansible.builtin.password', '.icinga-server-ticketsalt') }}"
-      NodeName: "{{ ansible_fqdn }}"
+      NodeName: "{{ ansible_facts['fqdn'] }}"
       ZoneName: "main"
     icinga2_confd: false # Disable example configuration
     icinga2_purge_features: yes # Ansible will manage all features
@@ -239,11 +239,11 @@ This is a example on how to install Icinga 2 server with Icinga Web 2 and Icinga
       - name: api
         ca_host: none
         endpoints:
-          - name: "{{ ansible_fqdn }}"
+          - name: "{{ ansible_facts['fqdn'] }}"
         zones:
           - name: "main"
             endpoints:
-              - "{{ ansible_fqdn }}"
+              - "{{ ansible_facts['fqdn'] }}"
   pre_tasks:
     - ansible.builtin.include_role:
         name: netways.icinga.repos

--- a/doc/role-icinga2/features/feature-api.md
+++ b/doc/role-icinga2/features/feature-api.md
@@ -163,7 +163,7 @@ icinga2_features:
   * Force new certificates on the destination hosts.
 
 * `cert_name: string`
-  * Common name of Icinga client/server instance. Default is **ansible_fqdn**.
+  * Common name of Icinga client/server instance. Default is **ansible_facts['fqdn']**.
 
 * `ssl_cacert: string`
   * Path to the ca file when using manual certificates

--- a/doc/role-icinga2/objects.md
+++ b/doc/role-icinga2/objects.md
@@ -33,7 +33,7 @@ webserver.example.org:
     host.example.org:
       - name: "{{ inventory_hostname }}"
         type: Host
-        file: "{{ 'conf.d/' + ansible_hostname + '.conf' }}"
+        file: "{{ 'conf.d/' + ansible_facts['hostname'] + '.conf' }}"
         address: "{{ ansible_host }}"
         check_command: hostalive
         check_interval: 3m
@@ -72,10 +72,10 @@ You can use this variant within a playbook where `host.example.org` is your cent
               imports:
                 - linux-host
               vars:
-                distro: "{{ ansible_distribution }}"
-                distroversion: "{{ ansible_distribution_version }}"
-                arch: "{{ ansible_architecture }}"
-              address: "{{ ansible_default_ipv4.address }}"
+                distro: "{{ ansible_facts['distribution'] }}"
+                distroversion: "{{ ansible_facts['distribution_version'] }}"
+                arch: "{{ ansible_facts['architecture'] }}"
+              address: "{{ ansible_facts['default_ipv4']['address'] }}"
   roles:
     - netways.icinga.icinga2
 ```
@@ -89,7 +89,7 @@ webserver.example.org:
   icinga2_objects:
     - name: "web-api-user"
       type: ApiUser
-      file: "{{ 'conf.d/' + ansible_hostname + '.conf' }}"
+      file: "{{ 'conf.d/' + ansible_facts['hostname'] + '.conf' }}"
       password: "somepassword"
       permissions:
         - "objects/query/Host"

--- a/doc/role-icinga2/role-icinga2.md
+++ b/doc/role-icinga2/role-icinga2.md
@@ -35,10 +35,10 @@ icinga2_confd: true/false/<directory_name>
 
 The Icinga 2 role will automatically detect via Ansible facts if SELinux is enabled on the system. If this is the case the package icinga2-selinux will be automatically installed.
 
-If the package should be installed, even if SELinux is not enabled or somehow wrongly disabled in Ansible use the following variable.
+If the package should be installed, even if SELinux is not enabled or somehow wrongly disabled in Ansible, set the following fact.
 
 ```yaml
-ansible_selinux:
+selinux:
   status: enabled
 ```
 

--- a/doc/role-icingaweb2/module-director.md
+++ b/doc/role-icingaweb2/module-director.md
@@ -27,7 +27,7 @@ icingaweb2_modules:
     run_kickstart: true
     kickstart:
       config:
-        endpoint: "{{ ansible_fqdn }}"
+        endpoint: "{{ ansible_facts['fqdn'] }}"
         host: 127.0.0.1
         username: root
         password: root

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -118,11 +118,11 @@
       - name: api
         ca_host: none
         endpoints:
-          - name: "{{ ansible_fqdn }}"
+          - name: "{{ ansible_facts['fqdn'] }}"
         zones:
           - name: "main"
             endpoints:
-              - "{{ ansible_fqdn }}"
+              - "{{ ansible_facts['fqdn'] }}"
     icinga2_config_directories:
       - zones.d/main/commands
       - zones.d/main/hosts

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -9,4 +9,4 @@
           - apt-transport-https
           - python3-debian
         update_cache: yes
-      when: ansible_os_family == "Debian"
+      when: ansible_facts["os_family"] == "Debian"

--- a/molecule/local-default-pgsql/converge.yml
+++ b/molecule/local-default-pgsql/converge.yml
@@ -57,11 +57,11 @@
       - name: api
         ca_host: none
         endpoints:
-          - name: "{{ ansible_fqdn }}"
+          - name: "{{ ansible_facts['fqdn'] }}"
         zones:
           - name: "main"
             endpoints:
-              - "{{ ansible_fqdn }}"
+              - "{{ ansible_facts['fqdn'] }}"
     icinga2_config_directories:
       - zones.d/main/commands
       - zones.d/main/hosts

--- a/molecule/local-default-pgsql/prepare.yml
+++ b/molecule/local-default-pgsql/prepare.yml
@@ -10,4 +10,4 @@
           - apt-transport-https
           - python3-debian
         update_cache: yes
-      when: ansible_os_family == "Debian"
+      when: ansible_facts["os_family"] == "Debian"

--- a/molecule/local-default/converge.yml
+++ b/molecule/local-default/converge.yml
@@ -159,11 +159,11 @@
       - name: api
         ca_host: none
         endpoints:
-          - name: "{{ ansible_fqdn }}"
+          - name: "{{ ansible_facts['fqdn'] }}"
         zones:
           - name: "main"
             endpoints:
-              - "{{ ansible_fqdn }}"
+              - "{{ ansible_facts['fqdn'] }}"
     icinga2_config_directories:
       - zones.d/main/commands
       - zones.d/main/hosts

--- a/molecule/local-default/prepare.yml
+++ b/molecule/local-default/prepare.yml
@@ -10,4 +10,4 @@
           - apt-transport-https
           - python3-debian
         update_cache: yes
-      when: ansible_os_family == "Debian"
+      when: ansible_facts["os_family"] == "Debian"

--- a/molecule/role-icingadb/prepare.yml
+++ b/molecule/role-icingadb/prepare.yml
@@ -9,4 +9,4 @@
           - apt-transport-https
           - python3-debian
         update_cache: yes
-      when: ansible_os_family == "Debian"
+      when: ansible_facts["os_family"] == "Debian"

--- a/molecule/role-icingadb_redis/prepare.yml
+++ b/molecule/role-icingadb_redis/prepare.yml
@@ -9,4 +9,4 @@
           - apt-transport-https
           - python3-debian
         update_cache: yes
-      when: ansible_os_family == "Debian"
+      when: ansible_facts["os_family"] == "Debian"

--- a/molecule/role-icingaweb2/prepare.yml
+++ b/molecule/role-icingaweb2/prepare.yml
@@ -9,4 +9,4 @@
           - apt-transport-https
           - python3-debian
         update_cache: yes
-      when: ansible_os_family == "Debian"
+      when: ansible_facts["os_family"] == "Debian"

--- a/roles/icinga2/defaults/main.yml
+++ b/roles/icinga2/defaults/main.yml
@@ -17,4 +17,4 @@ icinga2_features:
 icinga2_objects: []
 icinga2_remote_objects: []
 _icinga2_custom_conf_paths: []
-icinga2_config_host: "{{ ansible_fqdn }}"
+icinga2_config_host: "{{ ansible_facts['fqdn'] }}"

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -2,7 +2,7 @@
 
 - name: set api feature facts
   set_fact:
-    icinga2_cert_name: "{{ icinga2_dict_features.api.cert_name | default(ansible_fqdn) }}"
+    icinga2_cert_name: "{{ icinga2_dict_features.api.cert_name | default(ansible_facts['fqdn']) }}"
     icinga2_ca_host: "{{ icinga2_dict_features.api.ca_host | default(omit) }}"
     icinga2_ca_host_port: "{{ icinga2_dict_features.api.ca_host_port | default(omit) }}"
     icinga2_ca_fingerprint: "{{ icinga2_dict_features.api.ca_fingerprint | default(omit) }}"

--- a/roles/icinga2/tasks/features/idomysql.yml
+++ b/roles/icinga2/tasks/features/idomysql.yml
@@ -14,8 +14,8 @@
         file: features-available/ido-mysql.conf
         args: "{{ icinga2_dict_features.idomysql }}"
 
-- name: install on {{ ansible_os_family }}
-  include_tasks: "features/idomysql/install_on_{{ ansible_os_family }}.yml"
+- name: "install on {{ ansible_facts['os_family'] }}"
+  include_tasks: "features/idomysql/install_on_{{ ansible_facts['os_family'] }}.yml"
 
 # Hint: For MySQL the client-side --ssl option is deprecated as of MySQL 5.7.11 and is removed in MySQL 8.0. For client programs, use --ssl-mode instead
 # However, MariaDB currently does not offer a --ssl-mode option, MariaDB enables --ssl automatically with other flags

--- a/roles/icinga2/tasks/features/idopgsql.yml
+++ b/roles/icinga2/tasks/features/idopgsql.yml
@@ -14,8 +14,8 @@
         file: features-available/ido-pgsql.conf
         args: "{{ icinga2_dict_features.idopgsql }}"
 
-- name: install on {{ ansible_os_family }}
-  include_tasks: "features/idopgsql/install_on_{{ ansible_os_family }}.yml"
+- name: "install on {{ ansible_facts['os_family'] }}"
+  include_tasks: "features/idopgsql/install_on_{{ ansible_facts['os_family'] }}.yml"
 
 - name: PostgreSQL import IDO schema
   block:

--- a/roles/icinga2/tasks/install.yml
+++ b/roles/icinga2/tasks/install.yml
@@ -2,17 +2,17 @@
 - name: Check supported operatingsystems
   vars:
     _paths: "{{ ansible_search_path }}"
-    _file: "install_on_{{ ansible_os_family }}.yml"
+    _file: "install_on_{{ ansible_facts['os_family'] }}.yml"
     _tasks_file: "{{ lookup('first_found', paths=_paths, files=_file, skip=true) }}"
   block:
-    - name: Install on {{ ansible_os_family }}
+    - name: Install on {{ ansible_facts['os_family'] }}
       when: _tasks_file | length > 0
-      ansible.builtin.include_tasks: "install_on_{{ ansible_os_family }}.yml"
+      ansible.builtin.include_tasks: "install_on_{{ ansible_facts['os_family'] }}.yml"
 
     - name: "OS family not supported!"
       when: _tasks_file | length == 0
       ansible.builtin.fail:
-        msg: "The OS '{{ ansible_os_family }}' is not supported!"
+        msg: "The OS '{{ ansible_facts['os_family'] }}' is not supported!"
 
 - name: Prepare fragments path
   ansible.builtin.file:

--- a/roles/icinga2/tasks/install_on_RedHat.yml
+++ b/roles/icinga2/tasks/install_on_RedHat.yml
@@ -7,4 +7,4 @@
   ansible.builtin.yum:
     name: icinga2-selinux
     state: present
-  when: ansible_selinux is defined and ansible_selinux.status == "enabled"
+  when: ansible_facts["selinux"] is defined and ansible_facts["selinux"]["status"] == "enabled"

--- a/roles/icinga2/tasks/install_on_Suse.yml
+++ b/roles/icinga2/tasks/install_on_Suse.yml
@@ -8,4 +8,4 @@
   community.general.zypper:
     name: icinga2-selinux
     state: present
-  when: ansible_selinux is defined and ansible_selinux.status == "enabled"
+  when: ansible_facts["selinux"] is defined and ansible_facts["selinux"]["status"] == "enabled"

--- a/roles/icinga2/tasks/main.yml
+++ b/roles/icinga2/tasks/main.yml
@@ -6,10 +6,10 @@
   vars:
     params:
       files:
-        - "{{ ansible_os_family }}-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-        - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
-        - "{{ ansible_os_family }}-{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}.yml"
         - default.yml
       paths:
         - "{{ role_path }}/vars"

--- a/roles/icinga2/vars/Debian.yml
+++ b/roles/icinga2/vars/Debian.yml
@@ -11,6 +11,6 @@ icinga2_default_constants:
   PluginDir: /usr/lib/nagios/plugins
   ManubulonPluginDir: /usr/lib/nagios/plugins
   PluginContribDir: /usr/lib/nagios/plugins
-  NodeName: "{{ ansible_fqdn }}"
+  NodeName: "{{ ansible_facts['fqdn'] }}"
   ZoneName: NodeName
   TicketSalt: ''

--- a/roles/icinga2/vars/RedHat.yml
+++ b/roles/icinga2/vars/RedHat.yml
@@ -11,6 +11,6 @@ icinga2_default_constants:
   PluginDir: /usr/lib64/nagios/plugins
   ManubulonPluginDir: /usr/lib64/nagios/plugins
   PluginContribDir: /usr/lib64/nagios/plugins
-  NodeName: "{{ ansible_fqdn }}"
+  NodeName: "{{ ansible_facts['fqdn'] }}"
   ZoneName: NodeName
   TicketSalt: ''

--- a/roles/icinga2/vars/Suse-12.yml
+++ b/roles/icinga2/vars/Suse-12.yml
@@ -11,6 +11,6 @@ icinga2_default_constants:
   PluginDir: /usr/lib/nagios/plugins/
   ManubulonPluginDir: /usr/lib/nagios/plugins/
   PluginContribDir: /usr/lib/nagios/plugins/
-  NodeName: "{{ ansible_fqdn }}"
+  NodeName: "{{ ansible_facts['fqdn'] }}"
   ZoneName: NodeName
   TicketSalt: ''

--- a/roles/icinga2/vars/Suse.yml
+++ b/roles/icinga2/vars/Suse.yml
@@ -11,6 +11,6 @@ icinga2_default_constants:
   PluginDir: /usr/lib/nagios/plugins/
   ManubulonPluginDir: /usr/lib/nagios/plugins/
   PluginContribDir: /usr/lib/nagios/plugins/
-  NodeName: "{{ ansible_fqdn }}"
+  NodeName: "{{ ansible_facts['fqdn'] }}"
   ZoneName: NodeName
   TicketSalt: ''

--- a/roles/icinga_kubernetes/tasks/main.yml
+++ b/roles/icinga_kubernetes/tasks/main.yml
@@ -4,10 +4,10 @@
   vars:
     params:
       files:
-        - "{{ ansible_os_family }}-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-        - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
-        - "{{ ansible_os_family }}-{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}.yml"
         - default.yml
       paths:
         - "{{ role_path }}/vars"
@@ -15,17 +15,17 @@
 - name: Check supported operatingsystems
   vars:
     _paths: "{{ ansible_search_path }}"
-    _file: "install_on_{{ ansible_os_family | lower }}.yml"
+    _file: "install_on_{{ ansible_facts['os_family'] | lower }}.yml"
     _tasks_file: "{{ lookup('first_found', paths=_paths, files=_file, skip=true) }}"
   block:
     - name: Include OS specific installation
       when: _tasks_file | length > 0
-      ansible.builtin.include_tasks: "install_on_{{ ansible_os_family | lower }}.yml"
+      ansible.builtin.include_tasks: "install_on_{{ ansible_facts['os_family'] | lower }}.yml"
 
     - name: "OS family not supported!"
       when: _tasks_file | length == 0
       ansible.builtin.fail:
-        msg: "The OS '{{ ansible_os_family }}' is not supported!"
+        msg: "The OS '{{ ansible_facts['os_family'] }}' is not supported!"
 
 - name: Include Tasks to configure Icinga Kubernetes
   ansible.builtin.include_tasks: manage_config.yml

--- a/roles/icingadb/tasks/main.yml
+++ b/roles/icingadb/tasks/main.yml
@@ -4,10 +4,10 @@
   vars:
     params:
       files:
-        - "{{ ansible_os_family }}-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-        - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
-        - "{{ ansible_os_family }}-{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}.yml"
         - default.yml
       paths:
         - "{{ role_path }}/vars"
@@ -15,17 +15,17 @@
 - name: Check supported operatingsystems 
   vars:
     _paths: "{{ ansible_search_path }}"
-    _file: "install_on_{{ ansible_os_family | lower }}.yml"
+    _file: "install_on_{{ ansible_facts['os_family'] | lower }}.yml"
     _tasks_file: "{{ lookup('first_found', paths=_paths, files=_file, skip=true) }}"
   block:
     - name: Include OS specific installation
       when: _tasks_file | length > 0
-      ansible.builtin.include_tasks: "install_on_{{ ansible_os_family | lower }}.yml"
+      ansible.builtin.include_tasks: "install_on_{{ ansible_facts['os_family'] | lower }}.yml"
 
     - name: "OS family not supported!"
       when: _tasks_file | length == 0
       ansible.builtin.fail:
-        msg: "The OS '{{ ansible_os_family }}' is not supported!"
+        msg: "The OS '{{ ansible_facts['os_family'] }}' is not supported!"
 
 - name: Include Tasks to configure IcingaDB
   ansible.builtin.include_tasks: manage_config.yml

--- a/roles/icingadb_redis/tasks/main.yml
+++ b/roles/icingadb_redis/tasks/main.yml
@@ -4,10 +4,10 @@
   vars:
     params:
       files:
-        - "{{ ansible_os_family }}-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-        - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
-        - "{{ ansible_os_family }}-{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}.yml"
         - default.yml
       paths:
         - "{{ role_path }}/vars"
@@ -15,17 +15,17 @@
 - name: Check supported operatingsystems
   vars:
     _paths: "{{ ansible_search_path }}"
-    _file: "install_on_{{ ansible_os_family | lower }}.yml"
+    _file: "install_on_{{ ansible_facts['os_family'] | lower }}.yml"
     _tasks_file: "{{ lookup('first_found', paths=_paths, files=_file, skip=true) }}"
   block:
     - name: Include OS specific installation
       when: _tasks_file | length > 0
-      ansible.builtin.include_tasks: "install_on_{{ ansible_os_family | lower }}.yml"
+      ansible.builtin.include_tasks: "install_on_{{ ansible_facts['os_family'] | lower }}.yml"
 
     - name: "OS family not supported!"
       when: _tasks_file | length == 0
       ansible.builtin.fail:
-        msg: "The OS '{{ ansible_os_family }}' is not supported!"
+        msg: "The OS '{{ ansible_facts['os_family'] }}' is not supported!"
 
 - name: Manage IcingaDB Redis configuration
   ansible.builtin.include_tasks: "manage_config.yml"

--- a/roles/icingaweb2/tasks/main.yml
+++ b/roles/icingaweb2/tasks/main.yml
@@ -4,10 +4,10 @@
   vars:
     params:
       files:
-        - "{{ ansible_os_family | lower }}-{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-        - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-        - "{{ ansible_os_family | lower }}-{{ ansible_distribution | lower }}.yml"
-        - "{{ ansible_os_family | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}-{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_major_version'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}-{{ ansible_facts['distribution_major_version'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}-{{ ansible_facts['distribution'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}.yml"
         - default.yml
       paths:
         - "{{ role_path }}/vars"
@@ -37,17 +37,17 @@
 - name: Check supported operatingsystems
   vars:
     _paths: "{{ ansible_search_path }}"
-    _file: "install_on_{{ ansible_os_family | lower }}.yml"
+    _file: "install_on_{{ ansible_facts['os_family'] | lower }}.yml"
     _tasks_file: "{{ lookup('first_found', paths=_paths, files=_file, skip=true) }}"
   block:
     - name: Include OS specific installation
       when: _tasks_file | length > 0
-      ansible.builtin.include_tasks: "install_on_{{ ansible_os_family | lower }}.yml"
+      ansible.builtin.include_tasks: "install_on_{{ ansible_facts['os_family'] | lower }}.yml"
 
     - name: "OS family not supported!"
       when: _tasks_file | length == 0
       ansible.builtin.fail:
-        msg: "The OS '{{ ansible_os_family }}' is not supported!"
+        msg: "The OS '{{ ansible_facts['os_family'] }}' is not supported!"
 
 - name: Manage Icinga Web 2 config
   ansible.builtin.include_tasks: "manage_icingaweb_config.yml"

--- a/roles/ifw/tasks/main.yml
+++ b/roles/ifw/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Check if Icinga PowerShell Framework is installed
   ansible.windows.win_shell: Use-Icinga -Minimal
-  when: ansible_os_family == "Windows"
+  when: ansible_facts["os_family"] == "Windows"
   register: _use_icinga
   changed_when: false
   failed_when: false
@@ -10,23 +10,23 @@
 - name: Install Icinga PowerShell Framework
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/install_powershell_framework.yml"
   when:
-    - ansible_os_family == "Windows"
+    - ansible_facts["os_family"] == "Windows"
     - _use_icinga.stderr != ""
 
 - name: Manage repositories
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/manage_repositories.yml"
-  when: ansible_os_family == "Windows"
+  when: ansible_facts["os_family"] == "Windows"
 
 - name: Install Icinga Powershell Components
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/install_components.yml"
   when:
-    - ansible_os_family == "Windows"
+    - ansible_facts["os_family"] == "Windows"
     - ifw_components | length > 0
 
 - name: Configure Icinga 2
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/configure_icinga2.yml"
   when:
-    - ansible_os_family == "Windows"
+    - ansible_facts["os_family"] == "Windows"
     - ifw_components | selectattr('name', 'eq', 'agent') | length > 0
     - ifw_icinga2_parents is defined
     - ifw_icinga2_parent_zone is defined

--- a/roles/monitoring_plugins/defaults/main.yml
+++ b/roles/monitoring_plugins/defaults/main.yml
@@ -6,4 +6,4 @@ icinga_monitoring_plugins_crb: false
 icinga_monitoring_plugins_remove: true
 icinga_monitoring_plugins_autoremove: false
 icinga_monitoring_plugins_dependency_repos:
-  - "{{ 'powertools' if ansible_distribution_major_version | int == 8 and icinga_monitoring_plugins_crb else 'crb' if ansible_distribution_major_version | int >= 9 and icinga_monitoring_plugins_crb }}"
+  - "{{ 'powertools' if ansible_facts['distribution_major_version'] | int == 8 and icinga_monitoring_plugins_crb else 'crb' if ansible_facts['distribution_major_version'] | int >= 9 and icinga_monitoring_plugins_crb }}"

--- a/roles/monitoring_plugins/tasks/install_on_RedHat.yml
+++ b/roles/monitoring_plugins/tasks/install_on_RedHat.yml
@@ -12,7 +12,7 @@
     name: "{{ needed_packages }}"
     update_cache: true
   when:
-    - ansible_distribution_major_version | int < 8
+    - ansible_facts["distribution_major_version"] | int < 8
     - needed_packages is defined
     - needed_packages | length > 0
 
@@ -24,7 +24,7 @@
     update_cache: true
     enablerepo: "{{ icinga_monitoring_plugins_dependency_repos }}"
   when:
-    - ansible_distribution_major_version | int >= 8
+    - ansible_facts["distribution_major_version"] | int >= 8
     - needed_packages is defined
     - needed_packages | length > 0
 

--- a/roles/monitoring_plugins/tasks/main.yml
+++ b/roles/monitoring_plugins/tasks/main.yml
@@ -5,26 +5,26 @@
 - name: Check supported operatingsystems
   vars:
     _paths: "{{ role_path }}/vars"
-    _file: "{{ ansible_os_family }}.yml"
+    _file: "{{ ansible_facts['os_family'] }}.yml"
     _tasks_file: "{{ lookup('first_found', paths=_paths, files=_file, skip=true) }}"
   block:
     - name: Include OS family specific vars
       when: _tasks_file | length > 0
-      ansible.builtin.include_vars: "{{ role_path }}/vars/{{ ansible_os_family }}.yml"
+      ansible.builtin.include_vars: "{{ role_path }}/vars/{{ ansible_facts['os_family'] }}.yml"
 
     - name: "OS family not supported!"
       when: _tasks_file | length == 0
       ansible.builtin.fail:
-        msg: "The OS '{{ ansible_os_family }}' is not supported!"
+        msg: "The OS '{{ ansible_facts['os_family'] }}' is not supported!"
 
 - name: Include OS distribution/version specific vars
   include_vars: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:
-        - "{{ ansible_os_family }}-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-        - "{{ ansible_os_family }}-{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
         - "default.yml"
       paths:
         - "{{ role_path }}/vars"
@@ -58,4 +58,4 @@
     unwanted_packages: "{{ icinga_monitoring_plugins_available_packages | map(attribute='pkg_name') | difference(needed_packages | default ([])) }}"
 
 - name: Install
-  include_tasks: "install_on_{{ ansible_os_family }}.yml"
+  include_tasks: "install_on_{{ ansible_facts['os_family'] }}.yml"

--- a/roles/repos/defaults/main.yml
+++ b/roles/repos/defaults/main.yml
@@ -17,10 +17,10 @@ icinga_repo_zypper_snapshot_url: "https://packages.icinga.com/openSUSE/$releasev
 
 icinga_repo_apt_key: "{{ icinga_repo_gpgkey }}"
 icinga_repo_apt_keyring: /etc/apt/keyrings/icinga-archive-keyring.asc
-icinga_repo_apt_url: "http://packages.icinga.com/{{ ansible_distribution | lower }}"
-icinga_repo_apt_stable_deb: "icinga-{{ ansible_distribution_release | lower }}"
-icinga_repo_apt_testing_deb: "icinga-{{ ansible_distribution_release | lower }}-testing"
-icinga_repo_apt_snapshot_deb: "icinga-{{ ansible_distribution_release | lower }}-snapshots"
+icinga_repo_apt_url: "http://packages.icinga.com/{{ ansible_facts['distribution'] | lower }}"
+icinga_repo_apt_stable_deb: "icinga-{{ ansible_facts['distribution_release'] | lower }}"
+icinga_repo_apt_testing_deb: "icinga-{{ ansible_facts['distribution_release'] | lower }}-testing"
+icinga_repo_apt_snapshot_deb: "icinga-{{ ansible_facts['distribution_release'] | lower }}-snapshots"
 
 icinga_repo_gpgkey: "https://packages.icinga.com/icinga.key"
 icinga_repo_stable: true

--- a/roles/repos/tasks/RedHat.yml
+++ b/roles/repos/tasks/RedHat.yml
@@ -47,5 +47,5 @@
     state: present
   when:
     - icinga_repo_scl|bool == true
-    - ansible_distribution == "CentOS"
-    - ansible_distribution_major_version < "8"
+    - ansible_facts["distribution"] == "CentOS"
+    - ansible_facts["distribution_major_version"] < "8"

--- a/roles/repos/tasks/main.yml
+++ b/roles/repos/tasks/main.yml
@@ -4,11 +4,11 @@
   vars:
     params:
       files:
-        - "{{ ansible_os_family }}-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-        - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
-        - "{{ ansible_os_family }}-{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}-{{ ansible_lsb.id if ansible_lsb.id is defined else ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['lsb']['id'] if ansible_facts['lsb']['id'] is defined else ansible_facts['distribution'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}.yml"
         - default.yml
       paths:
         - "{{ role_path }}/vars"
@@ -18,10 +18,10 @@
   vars:
     params:
       files:
-        - "subscription-{{ ansible_os_family }}-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-        - "subscription-{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
-        - "subscription-{{ ansible_os_family }}-{{ ansible_distribution }}.yml"
-        - "subscription-{{ ansible_os_family }}.yml"
+        - "subscription-{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+        - "subscription-{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+        - "subscription-{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution'] }}.yml"
+        - "subscription-{{ ansible_facts['os_family'] }}.yml"
         - default.yml
       paths:
         - "{{ role_path }}/vars"
@@ -32,14 +32,14 @@
 - name: Check OS family
   vars:
     _paths: "{{ ansible_search_path }}"
-    _file: "{{ ansible_os_family }}.yml"
+    _file: "{{ ansible_facts['os_family'] }}.yml"
     _tasks_file: "{{ lookup('first_found', paths=_paths, files=_file, skip=true) }}"
   block:
-    - name: Add repositories {{ ansible_os_family }}
+    - name: Add repositories {{ ansible_facts['os_family'] }}
       when: _tasks_file | length > 0
-      ansible.builtin.include_tasks: "{{ ansible_os_family }}.yml"
+      ansible.builtin.include_tasks: "{{ ansible_facts['os_family'] }}.yml"
 
     - name: "OS family not supported!"
       when: _tasks_file | length == 0
       ansible.builtin.fail:
-        msg: "The OS '{{ ansible_os_family }}' is not supported!"
+        msg: "The OS '{{ ansible_facts['os_family'] }}' is not supported!"

--- a/roles/repos/vars/Debian-Raspbian.yml
+++ b/roles/repos/vars/Debian-Raspbian.yml
@@ -1,7 +1,7 @@
 ---
 icinga_repo_apt_stable_deb: # noqa var-naming
-  "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_lsb.id | lower }} icinga-{{ ansible_distribution_release | lower }} main"
+  "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_lsb.id | lower }} icinga-{{ ansible_facts['distribution_release'] | lower }} main"
 icinga_repo_apt_testing_deb: # noqa var-naming
-  "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_lsb.id | lower }} icinga-{{ ansible_distribution_release | lower }}-testing main"
+  "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_lsb.id | lower }} icinga-{{ ansible_facts['distribution_release'] | lower }}-testing main"
 icinga_repo_apt_snapshot_deb: # noqa var-naming
-  "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_lsb.id | lower }} icinga-{{ ansible_distribution_release | lower }}-snapshots main"
+  "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_lsb.id | lower }} icinga-{{ ansible_facts['distribution_release'] | lower }}-snapshots main"

--- a/roles/repos/vars/subscription-RedHat-Amazon.yml
+++ b/roles/repos/vars/subscription-RedHat-Amazon.yml
@@ -1,7 +1,7 @@
 ---
 icinga_repo_yum_stable_url: "https://packages.icinga.com/subscription/amazon/al$releasever/release/"
-icinga_repo_yum_stable_description: "ICINGA (stable release for al{{ ansible_distribution_major_version }})"
+icinga_repo_yum_stable_description: "ICINGA (stable release for al{{ ansible_facts['distribution_major_version'] }})"
 icinga_repo_yum_testing_url: "https://packages.icinga.com/subscription/amazon/al$releasever/testing/"
-icinga_repo_yum_testing_description: "ICINGA (testing release for al{{ ansible_distribution_major_version }})"
+icinga_repo_yum_testing_description: "ICINGA (testing release for al{{ ansible_facts['distribution_major_version'] }})"
 icinga_repo_yum_snapshot_url: "https://packages.icinga.com/subscription/amazon/al$releasever/snapshot/"
-icinga_repo_yum_snapshot_description: "ICINGA (snapshot release al{{ ansible_distribution_major_version }})"
+icinga_repo_yum_snapshot_description: "ICINGA (snapshot release al{{ ansible_facts['distribution_major_version'] }})"


### PR DESCRIPTION
With ansible-core 2.24 facts are no longer injected as top level variables by default (e.g. no more automatic 'ansible_os_family').

This commit adjusts references to facts to use the explicit syntax of e.g. 'ansible_facts["os_family"]' instead.