### PR TITLE
Fix escaping of special characters in INI writer

### DIFF
--- a/changelogs/fragments/426-quotes-and-escaping-ini-writer.yml
+++ b/changelogs/fragments/426-quotes-and-escaping-ini-writer.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix escaping of special characters within the generic INI writer (:code:`icingaweb2` role). Values are now enclosed by double quotes while using the :code:`to_json` filter for the escaping (#426).

--- a/molecule/ini-configuration-tests/tests/integration/test_ini_config.py
+++ b/molecule/ini-configuration-tests/tests/integration/test_ini_config.py
@@ -2,7 +2,7 @@ def test_string(host):
     i2_file = host.file("/tmp/string")
     print(i2_file.content_string)
     assert i2_file.is_file
-    assert i2_file.content_string == "\n[section]\ntest = string\n"
+    assert i2_file.content_string == '\n[section]\ntest = "string"\n'
 
 def test_number(host):
     i2_file = host.file("/tmp/number")

--- a/roles/icingaweb2/templates/ini_template.j2
+++ b/roles/icingaweb2/templates/ini_template.j2
@@ -3,14 +3,10 @@
 
 [{{ section }}]
 {% for option, value in options.items() %}
-{% if value is number %}
-{{ option }} = "{{ value | quote }}"
-{% elif value is iterable and (value is not string and value is not mapping) %}
+{% if value is iterable and (value is not string and value is not mapping) %}
 {{ option }} = "{{ value | join(', ') }}"
-{% elif ( value is string and ( "=" in value or "!" in value or " " in value ) )%}
-{{ option }} = "{{ value }}"
 {% else %}
-{{ option }} = {{ value }}
+{{ option }} = "{{ value | to_json | trim('"') }}"
 {% endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Values are now enclosed by double quotes while using the `to_json` filter for the escaping.  
This makes the values "JSON-safe" which should always be "INI-safe" as well.