### PR TITLE
Icinga2 templating support to fix issue #428

### DIFF
--- a/changelogs/fragments/428_icinga2_inventory-templating.yml
+++ b/changelogs/fragments/428_icinga2_inventory-templating.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add templating support for :code:`url`, :code:`user` and :code:`password` variables in :code:`netways.icinga.icinga` inventory plugin to support loading them from :code:`ansible-vault`. Thanks @johannesst

--- a/plugins/inventory/icinga.py
+++ b/plugins/inventory/icinga.py
@@ -498,7 +498,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
         self._read_config_data(path)
 
         # Set attributes based on parsed file
-        self.icinga_url      = self.get_option('url').strip('/')
+        self.icinga_url      = self.get_option('url')
         self.icinga_port     = self.get_option('port')
         self.icinga_user     = self.get_option('user')
         self.icinga_password = self.get_option('password')
@@ -516,7 +516,16 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
         self.keyed_groups    = self.get_option('keyed_groups')
         self.strict          = self.get_option('strict')
 
+        # Jinja2 templating for url, user and password
+        if self.templar.is_template(self.icinga_url):
+            self.icinga_url = self.templar.template(variable=self.icinga_url)
+        if self.templar.is_template(self.icinga_user):
+            self.icinga_user = self.templar.template(variable=self.icinga_user)
+        if self.templar.is_template(self.icinga_password):
+            self.icinga_password = self.templar.template(variable=self.icinga_password)
+
         # Build API URL and validate
+        self.icinga_url      = self.icinga_url.rstrip('/')
         self.api_url         = f'{self.icinga_url}:{self.icinga_port}/v1'
         if not self._validate_url(self.api_url):
             raise ValueError(f'\'{self.api_url}\' is not a valid URL.')


### PR DESCRIPTION
I tried fixing https://github.com/NETWAYS/ansible-collection-icinga/issues/428 by stealing from https://github.com/ansible-collections/community.general/pull/7996 which fixed this for the icinga_inventory plugin of the community.general collection.

At least in my test it worked as expected (I can now use vaulted variables for the variables) but I might have missed something. So I appreciate any feedback what's to improve or what I might have missed.

I also want to apologise for the noise through #429 I messed up the workflow due to my inexperience in participating via github.