### PR TITLE
Fix broken YAML in IFW command

### DIFF
--- a/changelogs/fragments/432_ifw_install_icinga_command.yml
+++ b/changelogs/fragments/432_ifw_install_icinga_command.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "The IfW `InstallCommand` now uses double quotes around the JSON to avoid timeouts during the task (#432). Thanks @afeefghannam89 for bringing up the topic again and testing the fix."

--- a/roles/ifw/tasks/configure_icinga2.yml
+++ b/roles/ifw/tasks/configure_icinga2.yml
@@ -158,4 +158,4 @@
   async: 300
   poll: 30
   when: _assertion_result.evaluated_to is defined
-  ansible.windows.win_shell: "Install-Icinga -InstallCommand '{{ _install_command }}'"
+  ansible.windows.win_shell: 'Install-Icinga -InstallCommand "{{ _install_command }}"'


### PR DESCRIPTION
Change the `Set up Icinga` task to use a YAML multiline literal block (`|`) so the command is treated as raw text.

This prevents YAML from interpreting any JSON syntax and ensures the complete command is passed unchanged to PowerShell.