### PR TITLE
Add prefix to service name when using 'apply_for'

### DIFF
--- a/changelogs/fragments/fix_434_apply_rule_names.yml
+++ b/changelogs/fragments/fix_434_apply_rule_names.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - The :code:`icinga2_object` plugin did not make use of the :code:`name` parameter passed to it when using :code:`apply_for`.
+    If more than one service used the same :code:`apply_for`, this would result in multiple services with the same name, thus leading to failure (#434).
+    The plugin now uses the :code:`name` as a prefix for the service name.

--- a/plugins/action/icinga2_object.py
+++ b/plugins/action/icinga2_object.py
@@ -79,7 +79,7 @@ class ActionModule(ActionBase):
                     if 'apply_target' in obj and obj['apply_target']:
                         object_content += ' ' + object_name + ' to ' + obj['apply_target']
                     elif 'apply_for' in obj and obj['apply_for']:
-                        object_content += ' for (' + obj['apply_for'] + ') '
+                        object_content += ' ' + object_name + ' for (' + obj['apply_for'] + ') '
                         r = re.search(r'^(.+)\s+in\s+', obj['apply_for'])
                         if r:
                             tmp = r.group(1).strip()


### PR DESCRIPTION
As per #434, not more than one service with the same `apply_for` could be used since the name of the service solely resulted from the `apply_for`, not taking `name` into consideration.

This adds the `name` parameter as a prefix to the service name, giving users to possibility to make the service name unique.