### PR TITLE
icingaweb2: Validate icingaweb2_config.security

### DIFF
--- a/roles/icingaweb2/meta/argument_specs.yml
+++ b/roles/icingaweb2/meta/argument_specs.yml
@@ -143,6 +143,19 @@ argument_specs:
                   - Defines where Icinga Web 2 modules are located on the filesystem.
                 type: str
                 required: true
+          security:
+            description:
+              - Defines security options for Icinga Web 2, currently only CSP.
+            type: dict
+            required: false
+            options:
+              use_strict_csp:
+                description:
+                  - Set this to 1 to enable strict Content Security Policy (CSP).
+                type: int
+                required: false
+                default: 0
+                choices: [ 0, 1 ]
           logging:
             description:
               - Defines the logging behavior of Icinga Web 2.


### PR DESCRIPTION
With the update to 0.4.6, the Icinga Web 2 configuration received a validation through argument_specs. This missed the security[^0] section, rendering my Ansible playbook invalid. Thus, the section was added.

[^0]: https://icinga.com/docs/icinga-web/latest/doc/03-Configuration/#security-configuration