### PR TITLE
Add optional definition of 'icingadb.env' to 'icingadb' feature

### DIFF
--- a/changelogs/fragments/fix_450_icingadb_environment.yml
+++ b/changelogs/fragments/fix_450_icingadb_environment.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - |
+    Add option :code:`environment_id` to the :code:`icingadb` feature (role :code:`icinga2`).
+    This allows users to specify the content of :code:`/var/lib/icinga2/icingadb.env`.
+    Messing with this option can lead to duplicate entries in the database, so be sure to first read the `documentation <https://icinga.com/docs/icinga-db/latest/doc/05-Distributed-Setups/#environment-id>`__ in case you really need to make use of this option.

--- a/doc/role-icinga2/features/feature-icingadb.md
+++ b/doc/role-icinga2/features/feature-icingadb.md
@@ -51,3 +51,9 @@ icinga2_features:
 
 * `connect_timeout: int`
   * Timeout for establishing new connections. Within this time, the TCP, TLS (if enabled) and Redis handshakes must complete. Defaults to 15s.
+
+* `environment_id: string`
+  * The environment ID for IcingaDB.
+    If set, this will be written to `/var/lib/icinga2/icingadb.env`.
+    This must be a 40 character long hexadecimal number (`[0-9a-f]`).<br>
+    Be cautious about using this argument and read up on the [documentation](https://icinga.com/docs/icinga-db/latest/doc/05-Distributed-Setups/#environment-id) beforehand.

--- a/roles/icinga2/tasks/features/icingadb.yml
+++ b/roles/icinga2/tasks/features/icingadb.yml
@@ -8,5 +8,15 @@
       - name: icingadb
         type: IcingaDB
         file: features-available/icingadb.conf
-        args: "{{ icinga2_dict_features.icingadb }}"
+        args: "{{ icinga2_dict_features.icingadb | combine({'environment_id': omit}) }}"
   register: result
+
+- name: Set Icinga DB environment ID
+  when: icinga2_dict_features.icingadb.environment_id is defined
+  ansible.builtin.copy:
+    dest: "{{ icinga2_data_path }}/icingadb.env"
+    content: "\"{{ icinga2_dict_features.icingadb.environment_id }}\""
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
+    mode: "0600"
+  notify: check-and-reload-icinga2-service

--- a/roles/icinga2/vars/Debian.yml
+++ b/roles/icinga2/vars/Debian.yml
@@ -4,6 +4,7 @@ icinga2_user: nagios
 icinga2_group: nagios
 icinga2_config_path: /etc/icinga2
 icinga2_log_path: /var/log/icinga2
+icinga2_data_path: /var/lib/icinga2
 icinga2_ca_path: /var/lib/icinga2/ca
 icinga2_cert_path: /var/lib/icinga2/certs
 icinga2_fragments_path: /var/tmp/icinga

--- a/roles/icinga2/vars/RedHat.yml
+++ b/roles/icinga2/vars/RedHat.yml
@@ -4,6 +4,7 @@ icinga2_user: icinga
 icinga2_group: icinga
 icinga2_config_path: /etc/icinga2
 icinga2_log_path: /var/log/icinga2
+icinga2_data_path: /var/lib/icinga2
 icinga2_ca_path: /var/lib/icinga2/ca
 icinga2_cert_path: /var/lib/icinga2/certs
 icinga2_fragments_path: /var/tmp/icinga

--- a/roles/icinga2/vars/Suse-12.yml
+++ b/roles/icinga2/vars/Suse-12.yml
@@ -4,6 +4,7 @@ icinga2_user: icinga
 icinga2_group: icinga
 icinga2_config_path: /etc/icinga2
 icinga2_log_path: /var/log/icinga2
+icinga2_data_path: /var/lib/icinga2
 icinga2_ca_path: /var/lib/icinga2/ca
 icinga2_cert_path: /var/lib/icinga2/certs
 icinga2_fragments_path: /var/tmp/icinga

--- a/roles/icinga2/vars/Suse.yml
+++ b/roles/icinga2/vars/Suse.yml
@@ -4,6 +4,7 @@ icinga2_user: icinga
 icinga2_group: icinga
 icinga2_config_path: /etc/icinga2
 icinga2_log_path: /var/log/icinga2
+icinga2_data_path: /var/lib/icinga2
 icinga2_ca_path: /var/lib/icinga2/ca
 icinga2_cert_path: /var/lib/icinga2/certs
 icinga2_fragments_path: /var/tmp/icinga


### PR DESCRIPTION
This allows users to set the value for `/var/lib/icinga2/icingadb.env`. This sets the Icinga DB environment ID and gives users a little more granular control over the 'icingadb' feature.