### PR TITLE
Rename reserved 'args' fact to avoid warnings (#449)

### DIFF
--- a/changelogs/fragments/fix_449_reserved_args_variable.yml
+++ b/changelogs/fragments/fix_449_reserved_args_variable.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Avoid warnings about the reserved variable name :code:`args` in the :code:`icinga2` role. (#449)

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -22,7 +22,7 @@
 
 - name: api feature cleanup arguments list
   set_fact:
-    icinga2_api_listener_args: "{{ icinga2_api_listener_args|default({}) | combine({idx.key: idx.value}) }}"
+    icinga2_api_listener_args: "{{ icinga2_api_listener_args | default({}) | combine({idx.key: idx.value}) }}"
   when: idx.key not in ['ca_host', 'ca_host_port', 'cert_name', 'ca_fingerprint', 'force_newcert', 'zones', 'endpoints', 'ssl_cacert', 'ssl_key', 'ssl_cert', 'ssl_remote_source', 'ticket_salt' ]
   loop: "{{ icinga2_dict_features.api | dict2items }}"
   loop_control:

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -22,7 +22,7 @@
 
 - name: api feature cleanup arguments list
   set_fact:
-    args: "{{ args|default({}) | combine({idx.key: idx.value}) }}"
+    icinga2_api_listener_args: "{{ icinga2_api_listener_args|default({}) | combine({idx.key: idx.value}) }}"
   when: idx.key not in ['ca_host', 'ca_host_port', 'cert_name', 'ca_fingerprint', 'force_newcert', 'zones', 'endpoints', 'ssl_cacert', 'ssl_key', 'ssl_cert', 'ssl_remote_source', 'ticket_salt' ]
   loop: "{{ icinga2_dict_features.api | dict2items }}"
   loop_control:
@@ -36,7 +36,7 @@
       - name: api
         type: ApiListener
         file: features-available/api.conf
-        args: "{{ args }}"
+        args: "{{ icinga2_api_listener_args }}"
 
 - name: feature api Endpoint objects
   ansible.builtin.set_fact:
@@ -198,4 +198,4 @@
     - icinga2_ssl_cert_path.stat.exists == false or icinga2_ssl_key_path.stat.exists == false or icinga2_force_newcert 
 
 - set_fact:
-    args: None
+    icinga2_api_listener_args: None

--- a/roles/icinga2/tasks/features/idomysql.yml
+++ b/roles/icinga2/tasks/features/idomysql.yml
@@ -55,6 +55,3 @@
         < /usr/share/icinga2-ido-mysql/schema/mysql.sql
       when: db_schema.rc != 0
   when: icinga2_dict_features.idomysql.import_schema| default(False)
-
-- set_fact:
-    args: None

--- a/roles/icinga2/tasks/features/idopgsql.yml
+++ b/roles/icinga2/tasks/features/idopgsql.yml
@@ -52,6 +52,3 @@
         -w -f /usr/share/icinga2-ido-pgsql/schema/pgsql.sql
       when: db_schema.rc != 0
   when: icinga2_dict_features.idopgsql.import_schema| default(False)
-
-- set_fact:
-    args: None


### PR DESCRIPTION
Fixes #449 