### PR TITLE
Fix quoting of values passed to `imports`

### DIFF
--- a/changelogs/fragments/fix_317.yml
+++ b/changelogs/fragments/fix_317.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - Fix rendering of :code:`host.vars.xyz` within :code:`imports` when using :code:`icinga2_object`.
+    Previously, all list entries passed to `imports` were treated as plain strings and thus were quoted in the resulting configuration.
+    The values are now checked against the :code:`<obj>.vars` pattern and all defined constants to decide whether the values should be quoted or not. (#317)

--- a/plugins/action/icinga2_object.py
+++ b/plugins/action/icinga2_object.py
@@ -106,9 +106,10 @@ class ActionModule(ActionBase):
                 # imports?
                 #
                 if 'imports' in obj:
-                    for item in obj['imports']:
-                        object_content += '  import "' + str(item) + '"\n'
-                    object_content += '\n'
+                    # Push the 'imports' key to front index to be processed first
+                    tmp_items = list(obj['args'].items())
+                    tmp_items.insert(0, ('imports', obj['imports']))
+                    obj['args'] = dict(tmp_items)
 
                 #
                 # parser

--- a/plugins/module_utils/parse.py
+++ b/plugins/module_utils/parse.py
@@ -177,8 +177,11 @@ class Icinga2Parser(object):
         op = ''
 
         for attr, value in attrs.items():
+            if attr == 'imports':
+                for x in value:
+                    config += "%s%s %s\n" % (' '*indent, 'import', parser(x))
             # if re.search(r'^(assign|ignore) where$', attr):
-            if attr == 'assign' or attr == 'ignore':
+            elif attr == 'assign' or attr == 'ignore':
                 for x in value:
                     config += "%s%s %s\n" % (' '*indent, attr+' where', parser(x))
             elif attr == 'vars':


### PR DESCRIPTION
The `imports` key (`icinga2_object`) now compares values against potential references to `host.vars` and all defined constants to decide whether quoting the value is necessary.

Fixes #317