### PR TITLE
Rework api feature

### DIFF
--- a/changelogs/fragments/icinga2_api_deprecations.yml
+++ b/changelogs/fragments/icinga2_api_deprecations.yml
@@ -1,0 +1,15 @@
+deprecated_features:
+  - The use of :code:`ca_host` inside the Icinga 2 API feature is deprecated.
+    Use :code:`parent_host` instead.
+  - The use of :code:`ca_host_port` inside the Icinga 2 API feature is deprecated.
+    Use :code:`parent_port` instead.
+  - |
+    The use of :code:`ticket_salt` inside the Icinga 2 API feature is deprecated.
+    Use :code:`ticket` instead.
+    Such a ticket can be created from the actual secret :code:`TicketSalt` passing it to the :code:`netways.icinga.icinga2_ticket` filter.
+    Example: :code:`ticket: "{{ <common_name> | netways.icinga.icinga2_ticket(ticketsalt='<secret_ticket_salt>') }}"`.
+
+minor_changes:
+  - Add new module :code:`netways.icinga.icinga2_api` to handle setting up the node as a master / agent instance.
+    The module handles the constant :code:`NodeName` as well as writing :code:`zones.conf`,
+    and makes certificate requests to the parent node (if :code:`mode=agent`).

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -131,7 +131,7 @@ This is an example on how to install an Icinga 2 server/master instance.
       - zones.d/main/services
     icinga2_features:
       - name: api           # Enable Feature API
-        ca_host: none       # No CA host, CA will be created locally
+        parent_host: none       # No parent host, CA will be created locally
         endpoints:
           - name: NodeName
         zones:
@@ -169,7 +169,7 @@ This is an example on how to install an Icinga 2 agent instance.
     icinga2_purge_features: yes # Ansible will manage all features
     icinga2_features:
       - name: api           # Enable Feature API
-        ca_host: master.localdomain
+        parent_host: master.localdomain
         # Trusted Cert and Ticket will be gathered from this host.
         # Ticket will be "delegated" if the FQDN is not in your Ansible environment
         # use the variable icinga2_delegate_host in addition.
@@ -237,7 +237,7 @@ This is a example on how to install Icinga 2 server with Icinga Web 2 and Icinga
       - name: checker
       - name: mainlog
       - name: api
-        ca_host: none
+        parent_host: none
         endpoints:
           - name: "{{ ansible_facts['fqdn'] }}"
         zones:

--- a/doc/role-icinga2/features.md
+++ b/doc/role-icinga2/features.md
@@ -33,7 +33,7 @@ icinga2_features:
     host: localhost
     port: 3000
   - name: api
-    ca_host: none
+    parent_host: none
     force_newcert: false
     endpoints:
       - name: NodeName

--- a/doc/role-icinga2/features/feature-api.md
+++ b/doc/role-icinga2/features/feature-api.md
@@ -1,6 +1,6 @@
 ## Feature API
 
-The API Feature configures the API. The feature will manage
+The API feature configures the API. The feature will manage
 certificate, private key and CA certificate or will create
 a certificate signing requests. It also manages the **zones.conf**.
 
@@ -16,7 +16,7 @@ Example how to install an Agent:
 icinga2_features:
   - name: api
     force_newcert: false
-    ca_host: icinga-server.localdomain
+    parent_host: <ParentNodeFQDN/IPAddress>
     endpoints:
       - name: NodeName
       - name: <ParentNodeName>
@@ -37,7 +37,7 @@ Example how to install a master/server instance:
 icinga2_features:
   - name: api
     force_newcert: false
-    ca_host: none
+    parent_host: none
     endpoints:
       - name: NodeName
     zones:
@@ -48,56 +48,77 @@ icinga2_features:
 
 ### Instance with Certificate Authority
 
-To create an instance with a local CA, the API Feature parameter `ca_host` should be `none`.
+To create an instance with a local CA, the API feature parameter `parent_host` should be `none`.
 
 ```yaml
-ca_host: none
+parent_host: none
 ```
+
+### Agent Setup
+
+An agent (or satellite) setup can work in four different ways.
+
+In all cases of auto-signing the master instance must have a secret `TicketSalt` defined.
+
+**On-demand signing:**  
+The agent creates a CSR locally and then request signing via API.  
+Manual signing on the master instance is necessary.  
+For this, pass an empty ticket `ticket: ""`.  
+The `netways.icinga.icinga2_api` module used here will report changes with each execution until the certificate is signed.
+
+**Auto-signing with ticket:**  
+The agent can pass a ticket which the master instance can validate.  
+If the validation is successful, the agent receives its signed certificate.  
+You can use the `netways.icinga.icinga2_ticket` filter to create a valid ticket if you know the secret `TicketSalt`.  
+Example: `ticket: "{{ <common_name> | netways.icinga.icinga2_ticket(ticketsalt='<secret_ticket_salt>') }}"`
+
+**Auto-signing without ticket:**  
+Before the agent requests its certificate, the ticket is generated on the master instance.  
+For this to work `parent_host` must be the master since ticket creation is delegated to `parent_host`.  
+If the `parent_host` is not the master, `icinga2_delegate_host: <inventory_hostname of master>` can be set to delegate there instead.  
+
+**Auto-signing with reverse connection:**  
+Used in environments where the agent cannot connect to its parent but the parent can connect to the agent.  
+Here delegation to `parent_host` (or `icinga2_delegate_host`) is used to retrieve the CA certificate and generate a ticket.  
+This is used if `delegate_pki: true`.
 
 ### Generate Certificate Signing Requests
 
-Create Signing Request to get a certificate managed by the parameter `ca_host` and `ca_host_port`. If
+Create Signing Request to get a certificate managed by the parameter `parent_host` and `parent_port`. If
 set to the master/server hostname, FQDN or IP, the node setup tries to connect
-via API an retrieve the trusted certificate.
+via API and retrieve the trusted certificate.
 
 > [!INFO]
-> Ansible will delegate the ticket creation to the CA host. You can change this behaviour by setting 'icinga2_delegate_host' to match another Ansible alias.
+> Ansible will delegate the ticket creation to the `parent_host`. You can change this behaviour by setting 'icinga2_delegate_host' to match another Ansible alias.
 
 ```yaml
-ca_host: icinga-server.localdomain
-ca_host_port: 5665
+parent_host: icinga-server.localdomain
+parent_port: 5665
 ```
 
-> [!INFO]
-> In case your agent can't connect to the CA host/master, you can change ca_host to your satellite.
-> In addition you can use the variables `icinga2_delegate_host`
-> and `ticket_salt` to delegate ticket creation to one of your satellites instead.
-> But is will also work because the delegation task will be initiated by the Ansible controlhost.
-
-Example if connection and ticket creation should be on the satellite:
+Example if connection should be established to the satellite, resulting in on-demand certificate signing:
 
 ```yaml
 icinga2_features:
   - name: api
-    ca_host: icinga-satellite.localdomain
-    ticket_salt: "{{ icinga2_constants.ticket_salt }}"
+    parent_host: icinga-satellite.localdomain
+    ticket: ""
   [...]
-icinga2_delegate_host: icinga-satellite.localdomain
 ```
-Example if agent should connect to satellite and the tickets are generated on the
-master host.
+
+> In the above case, the `parent_host` is a satellite which does not have the secret `TicketSalt`, so we cannot delegate there for ticket creation.
+
+Example if agent should connect to satellite and the tickets are generated on the master host.
 
 ```yaml
 icinga2_features:
   - name: api
-    ca_host: icinga-satellite.localdomain
-    ticket_salt: "{{ icinga2_constants.ticket_salt }}"
+    parent_host: icinga-satellite.localdomain
   [...]
 icinga2_delegate_host: icinga-master.localdomain
 ```
 
-By default the FQDN is used as certificate common name, to put a name
-yourself:
+By default the FQDN is used as certificate common name, to put a name yourself:
 
 ```yaml
 cert_name: myown-commonname.fqdn
@@ -109,7 +130,7 @@ To force a new request set `force_newcert` to `true`:
 force_newcert: true
 ```
 
-To increase your security set `ca_fingerprint` to validate the certificate of the `ca_host`:
+To increase your security set `ca_fingerprint` to validate the CA certificate:
 
 ```yaml
 ca_fingerprint: "00 DE AD BE EF"
@@ -131,9 +152,9 @@ Use `delegate_pki: true` when the agent cannot initiate a connection to the CA h
 
 In this mode, the role:
 
-- fetches `ca.crt` from the `ca_host` via Ansible and copies it to the agent
+- fetches `ca.crt` from the `parent_host` via Ansible and copies it to the agent
 - generates a self-signed certificate on the agent
-- creates a ticket on the `ca_host` via `delegate_to`
+- creates a ticket on the `parent_host` via `delegate_to`
 - writes the ticket to `{{ icinga2_cert_path }}/ticket`
 
 Icinga then completes certificate signing automatically when the parent connects to the agent and the cluster handshake starts. This is not a fully offline / disconnected workflow.
@@ -141,7 +162,7 @@ Icinga then completes certificate signing automatically when the parent connects
 ```yaml
 icinga2_features:
   - name: api
-    ca_host: icinga-master.localdomain
+    parent_host: icinga-master.localdomain
     delegate_pki: true
     endpoints:
       - name: icinga-agent.localdomain
@@ -167,7 +188,7 @@ ssl_key: certificate.key
 ```
 
 > **_NOTE:_** All three parameters have to be set otherwise a signing request is built
-and `ca_host` must be defined.
+and `parent_host` must be defined.
 
 The role will copy the files from your Ansible controller node to
 **/var/lib/icinga2/certs** on the remote host. File names are
@@ -194,17 +215,26 @@ icinga2_features:
 
 ### Feature variables
 
-* `ca_host: string`
-  * Use to decide where to gather the certificates. When set to **None**, Ansible will create a local Certificate Authority on the Host. Use **hostname** or **ipaddress** as value.
+* `parent_host: string`
+  * Use to decide where to gather the certificates. When set to **none**, Ansible will create a local Certificate Authority on the Host. Use **hostname** or **ipaddress** as value.
 
 * `force_newcert: boolean`
   * Force new certificates on the destination hosts.
+
+* `force_newca: boolean`
+  * Force new CA on the destination hosts (master instance).
+
+* `ticket: string`
+  * A valid ticket for the given `cert_name`. Used for auto-signing the CSR. Can be generated using the `netways.icinga.icinga2_ticket` filter. If `ticket: ""`, on-demand signing is used.
 
 * `delegate_pki: boolean`
   * Skip outbound `pki save-cert` and `pki request` on the agent. Provision `ca.crt` and ticket through Ansible delegation and rely on Icinga CSR auto-signing when the parent connects inbound.
 
 * `cert_name: string`
   * Common name of Icinga client/server instance. Default is **ansible_facts['fqdn']**.
+
+* `ca_fingerprint: string`
+  * SHA256 fingerprint of the CA certificate. If defined, the fingerprint is validated.
 
 * `ssl_cacert: string`
   * Path to the ca file when using manual certificates

--- a/doc/role-icinga2/features/feature-api.md
+++ b/doc/role-icinga2/features/feature-api.md
@@ -229,7 +229,9 @@ icinga2_features:
   * Force new certificates on the destination hosts.
 
 * `force_newca: boolean`
-  * Force new CA on the destination hosts (master instance).
+  * Force new CA on the destination hosts (master instance).  
+    This of course invalidates the current certificates of all Icinga nodes in the cluster. They also need to be recreated from the new CA.  
+    Use with caution!
 
 * `ticket: string`
   * A valid ticket for the given `cert_name`. Used for auto-signing the CSR. Can be generated using the `netways.icinga.icinga2_ticket` filter. If `ticket: ""`, on-demand signing is used.

--- a/doc/role-icinga2/features/feature-api.md
+++ b/doc/role-icinga2/features/feature-api.md
@@ -66,21 +66,22 @@ Manual signing on the master instance is necessary.
 For this, pass an empty ticket `ticket: ""`.  
 The `netways.icinga.icinga2_api` module used here will report changes with each execution until the certificate is signed.
 
-**Auto-signing with ticket:**  
+**Auto-signing, providing a ticket:**  
 The agent can pass a ticket which the master instance can validate.  
 If the validation is successful, the agent receives its signed certificate.  
 You can use the `netways.icinga.icinga2_ticket` filter to create a valid ticket if you know the secret `TicketSalt`.  
 Example: `ticket: "{{ <common_name> | netways.icinga.icinga2_ticket(ticketsalt='<secret_ticket_salt>') }}"`
 
-**Auto-signing without ticket:**  
+**Auto-signing, without providing a ticket:**  
 Before the agent requests its certificate, the ticket is generated on the master instance.  
 For this to work `parent_host` must be the master since ticket creation is delegated to `parent_host`.  
 If the `parent_host` is not the master, `icinga2_delegate_host: <inventory_hostname of master>` can be set to delegate there instead.  
 
-**Auto-signing with reverse connection:**  
+**Auto-signing, with reverse connection:**  
 Used in environments where the agent cannot connect to its parent but the parent can connect to the agent.  
-Here delegation to `parent_host` (or `icinga2_delegate_host`) is used to retrieve the CA certificate and generate a ticket.  
-This is used if `delegate_pki: true`.
+Here delegation to `parent_host` (or `icinga2_delegate_host`) is used to retrieve the CA certificate and generate a ticket,
+so some tasks will be run on `parent_host` (or `icinga2_delegate_host`) directly.  
+This requires `delegate_pki: true` to be set.
 
 ### Generate Certificate Signing Requests
 
@@ -120,6 +121,9 @@ icinga2_delegate_host: icinga-master.localdomain
 
 By default the FQDN is used as certificate common name, to put a name yourself:
 
+> This is not recommended! Apart from endpoints in the master zone and satellite zones (due to the option for high availability)
+> every endpoint should use its FQDN as the `cert_name`. This is considered best practice.
+
 ```yaml
 cert_name: myown-commonname.fqdn
 ```
@@ -144,6 +148,9 @@ The fingerprint can be retrieved with OpenSSL:
 
 ```bash
 openssl x509 -noout -fingerprint -sha256 -inform pem -in /path/to/ca.crt
+
+# Verbose example for use on the master
+openssl x509 -noout -fingerprint -sha256 -inform pem -in /var/lib/icinga2/ca/ca.crt | cut -d '=' -f 2 | tr '[A-Z]' '[a-z]' | tr -d ':'
 ```
 
 ### Top-down connections
@@ -216,7 +223,7 @@ icinga2_features:
 ### Feature variables
 
 * `parent_host: string`
-  * Use to decide where to gather the certificates. When set to **none**, Ansible will create a local Certificate Authority on the Host. Use **hostname** or **ipaddress** as value.
+  * Use to decide where to gather the certificates. When set to **none**, Ansible will create a local Certificate Authority on the Host. Use **FQDN**, **hostname** or **ipaddress** as value.
 
 * `force_newcert: boolean`
   * Force new certificates on the destination hosts.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -126,7 +126,7 @@
         auth_token: testtoken123
       - name: mainlog
       - name: api
-        ca_host: none
+        parent_host: none
         endpoints:
           - name: "{{ ansible_facts['fqdn'] }}"
         zones:

--- a/molecule/local-default-pgsql/converge.yml
+++ b/molecule/local-default-pgsql/converge.yml
@@ -55,7 +55,7 @@
     icinga2_features:
       - name: mainlog
       - name: api
-        ca_host: none
+        parent_host: none
         endpoints:
           - name: "{{ ansible_facts['fqdn'] }}"
         zones:

--- a/molecule/local-default/converge.yml
+++ b/molecule/local-default/converge.yml
@@ -163,7 +163,7 @@
         auth_token: testtoken123
       - name: mainlog
       - name: api
-        ca_host: none
+        parent_host: none
         endpoints:
           - name: "{{ ansible_facts['fqdn'] }}"
         zones:

--- a/molecule/reverse-connect-pki/host_vars/icinga-agent.yml
+++ b/molecule/reverse-connect-pki/host_vars/icinga-agent.yml
@@ -8,7 +8,7 @@ icinga2_features:
   - name: checker
   - name: mainlog
   - name: api
-    ca_host: icinga-master
+    parent_host: icinga-master
     delegate_pki: true
     endpoints:
       - name: icinga-master

--- a/molecule/reverse-connect-pki/host_vars/icinga-master.yml
+++ b/molecule/reverse-connect-pki/host_vars/icinga-master.yml
@@ -7,7 +7,7 @@ icinga2_features:
   - name: checker
   - name: mainlog
   - name: api
-    ca_host: none
+    parent_host: none
     endpoints:
       - name: icinga-master
       - name: icinga-agent

--- a/playbooks/full_stack.yml
+++ b/playbooks/full_stack.yml
@@ -334,7 +334,7 @@
       - name: icingadb
         environment_id: "df29d078f1fdeffddf3bcce81a8194397d326e11" # just something fixed, so destroy/build work right away
       - name: api
-        ca_host: none
+        parent_host: none
         cert_name: "{{ icinga2_constants.NodeName }}"
         endpoints:
           - name: "{{ icinga2_constants.NodeName }}"

--- a/plugins/modules/icinga2_api.py
+++ b/plugins/modules/icinga2_api.py
@@ -1,0 +1,730 @@
+from ansible.module_utils.basic import AnsibleModule
+
+DOCUMENTATION = r'''
+module: icinga2_api
+short_description: Handles Icinga 2 API setup.
+description:
+  - Sets host up for communication with other Icinga 2 nodes.
+  - Initiates an Icinga 2 master / satellite / agent setup.
+  - Ensures correct C(NodeName) constant.
+  - Manages C(zones.conf).
+  - Does not manage the C(ApiListener) object / C(api) feature.
+version_added: WIP
+author: |
+  Matthias Döhler <matthias.doehler@netways.de>
+options:
+  mode:
+    description:
+      - Defines the configuration mode to run.
+      - O(mode=master) will set the host up as a master instance.
+        This will create a local CA and the certificate for the host itself.
+      - O(mode=agent) (and its alias O(mode=satellite)) will set the host up as an agent instance.
+        This will create a certificate and key for the host,
+        fetch the parent's certificate,
+        and make a certificate request to that parent.
+      - The configuration steps, like setting the C(NodeName), always happen.
+         If O(mode=config) the master / agent setup is skipped, saving a little time if already done previously.
+    type: str
+    default: agent
+    choices:
+      - agent
+      - satellite
+      - master
+      - config
+  cn:
+    description:
+      - Defines the common name (CN) of the host.
+        This name will be used to distinctly represent this host within the cluster.
+        The O(cn) will be written to C(constants.conf) and used in this host's certificate.
+      - If unspecified, the host's FQDN will be used as given by V(socket.getfqdn(\)).
+    type: str
+  host:
+    description:
+      - If O(mode=agent), V(host) will be used to fetch the parent's certificate and for certificate requests.
+        Used in combination with O(port).
+      - Required when O(mode=agent).
+    type: str
+    aliases:
+      - parent_host
+  port:
+    description:
+      - If O(mode=agent), V(port) will be used to fetch the parent's certificate and for certificate requests.
+        Used in combination with O(host).
+    default: 5665
+    type: int
+    aliases:
+      - parent_port
+  ticket:
+    description:
+      - Used for CSR auto signing. If unspecified, a request is made to the O(parent) without a valid ticket, leading to on-demand CSR signing.
+        With each execution of this module, new requests will be made until the host's CSR has been signed.
+      - |
+        The ticket for any C(CN) can be computed using the C(TicketSalt) secret found on the Icinga 2 master,
+        passing both values to P(netways.icinga.icinga2_ticket#filter).
+        Example: V(ticket: "{{ 'myCommonName' | netways.icinga.icinga2_ticket(ticketsalt='mySuperSecretTicketSalt'\) }}")
+    type: str
+  enable_feature:
+    description:
+      - Whether the C(api) feature should be enabled.
+      - This does not configure the C(ApiListener) object found in the C(api) feature, but merely enables it.
+        If you need to configure the feature, you can use P(netways.icinga.icinga2#role) to do so
+        or use other modules like M(ansible.builtin.template) to generate a configuration according to your needs.
+    default: true
+    type: bool
+  zones:
+    description:
+      - Defines C(zones.conf).
+        If left empty, C(zones.conf) will stay untouched.
+    default: []
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+          - Defines the name of the zone.
+        type: str
+      global:
+        description:
+          - Whether the zone is a global zone.
+        default: false
+        type: bool
+        aliases:
+          - _global
+      parent:
+        description:
+          - Defines the parent zone of O(zones[].name).
+        type: str
+      endpoints:
+        description:
+          - Defines the Icinga 2 endpoint objects.
+        type: list
+        elements: dict
+        suboptions:
+          cn:
+            description:
+              - Defines the endpoint object's name.
+            type: str
+            aliases:
+              - name
+          host:
+            description:
+              - Defines the endpoint object's C(host) attribute.
+            type: str
+          port:
+            description:
+              - Defines the endpoint object's C(port) attribute.
+            type: int
+  force_new_ca:
+    description:
+      - If O(mode=master) and O(force_new_ca=true), enforces the recreation of the CA certificate and key.
+    default: false
+    type: bool
+  force_new_cert:
+    description:
+      - If O(mode=master) or O(mode=agent), and O(force_new_cert=true), enforces the recreation of the host's certificate and key.
+    default: false
+    type: bool
+  fingerprint:
+    description:
+      - The fingerprint of the CA's certificate. This is used for validation.
+    type: str
+  ignore_fingerprint:
+    description:
+      - If O(ignore_fingerprint=true), no validation using the O(fingerprint) takes place.
+    default: false
+    type: bool
+
+requirements:
+    - icinga2
+
+seealso:
+    - name: Icinga 2 distributed monitoring
+      description: Official documentation about distributed monitoring with Icinga 2.
+      link: https://icinga.com/docs/icinga-2/latest/doc/06-distributed-monitoring/
+'''
+
+EXAMPLES = r'''
+- name: Agent setup using on-demand signing
+  netways.icinga.icinga2_api:
+    mode: agent
+    cn: "agent.example.com"
+    host: "master.example.com"
+    fingerprint: "fb7ebd67bb1b69eba4edec1204683b636d17b7393dad84f8c8ee66c5a1ad84ba"
+    zones:
+      # Define parent zone and connection details
+      - name: "master"
+        endpoints:
+          - cn: "master.example.com"
+            host: "10.0.0.30"
+      # Define own zone
+      - name: "agent.example.com"
+        parent: "master"
+        endpoints:
+          - cn: "agent.example.com"
+
+
+- name: Satellite setup using a ticket
+  netways.icinga.icinga2_api:
+    mode: agent
+    cn: "satellite.example.com"
+    host: "master.example.com"
+    ticket: "{{ 'satellite.example.com' | netways.icinga.icinga2_ticket(ticketsalt='mySecretTicketSalt') }}"
+    fingerprint: "fb7ebd67bb1b69eba4edec1204683b636d17b7393dad84f8c8ee66c5a1ad84ba"
+    zones:
+      # Define parent zone and connection details
+      - name: "master"
+        endpoints:
+          - cn: "master.example.com"
+            host: "10.0.0.30"
+      # Define own satellite zone called 'satellite'
+      - name: "satellite"
+        parent: "master"
+        endpoints:
+          - cn: "satellite.example.com"
+      # Global zones as needed
+      - name: "global-templates"
+        global: true
+      - name: "director-global"
+        global: true
+
+
+- name: Master setup defining multiple satellite zones and global zones
+  netways.icinga.icinga2_api:
+    mode: master
+    cn: "master.example.com"
+    zones:
+      # Define master zone
+      - name: "master"
+        endpoints:
+          - cn: "master.example.com"
+      # Define first satellite zone called 'us'
+      - name: "us"
+        parent: "master"
+        endpoints:
+          - cn: "us-satellite.example.com"
+            host: "us-satellite.example.com"
+      # Define second satellite zone called 'de'
+      - name: "de"
+        parent: "master"
+        endpoints:
+          - cn: "de-satellite.example.com"
+            host: "de-satellite.example.com"
+      # Global zones
+      - name: "global-templates"
+        global: true
+      - name: "director-global"
+        global: true
+'''
+
+RETURN = r'''
+cn:
+  description:
+    - The common name used.
+  type: str
+  returned: always
+  sample: example.com
+ca_fingerprint:
+  description:
+    - The sha256 fingerprint of the C(ca.crt).
+  type: str
+  returned: always
+  sample: fb7ebd67bb1b69eba4edec1204683b636d17b7393dad84f8c8ee66c5a1ad84ba
+cert_fingerprint:
+  description:
+    - The sha256 fingerprint of this host's certificate.
+  type: str
+  returned: always
+  sample: 53f33316caacd4342a12c130e5fa6d7a619565bd730ac58ef98f8b38a7e03e37
+'''
+
+import filecmp
+import shutil
+import socket
+import glob
+import os
+import re
+
+
+def verify_cert(module, ca_path, cert_path):
+    cmd = [
+        'icinga2',
+        'pki',
+        'verify',
+        '--cacert', ca_path,
+        '--cert', cert_path,
+    ]
+    rc, stdout, stderr = module.run_command(
+        cmd,
+        executable=None,
+        use_unsafe_shell=False,
+        encoding=None,
+        data=None,
+        binary_data=True,
+        expand_user_and_vars=True,
+    )
+    if rc != 0:
+        return False
+    return True
+
+
+def get_fingerprint(module, path):
+    fingerprint_pattern = r'Fingerprint:\s*(.*)$'
+    if os.path.isfile(path):
+        cmd = [
+            'icinga2',
+            'pki',
+            'verify',
+            '--cert', path,
+        ]
+        rc, stdout, stderr = module.run_command(
+            cmd,
+            executable=None,
+            use_unsafe_shell=False,
+            encoding=None,
+            data=None,
+            binary_data=True,
+            expand_user_and_vars=True,
+        )
+        match = re.search(fingerprint_pattern, str(stdout).strip('"'))
+        if match:
+            # Normalize fingerprint
+            fingerprint = match.group(1).replace('\\n', '').replace(' ', '').lower()
+            return fingerprint
+        return None
+
+
+def get_return_values(module, cn, ca_directory, certs_directory):
+    ### Get CA and certificate fingerprints
+    rv = dict(
+        cn = cn,
+        ca_fingerprint = None,
+        cert_fingerprint = None,
+    )
+    rv['ca_fingerprint'] = get_fingerprint(module, os.path.join(certs_directory, 'ca.crt'))
+    rv['cert_fingerprint'] = get_fingerprint(module, os.path.join(certs_directory, cn + '.crt'))
+    return rv
+
+
+def configure(module, cn, zones, enable_feature, sysconf_directory):
+    ret = dict(
+        changed = False,
+    )
+
+    ### Ensure const NodeName is set to given CN
+    with open(os.path.join(sysconf_directory, 'constants.conf'), 'r') as constants:
+        lines = constants.readlines()
+
+    new_lines = list()
+    pattern = '^const NodeName.*$'
+    target = 'const NodeName = "{}"'.format(cn)
+
+    for line in lines:
+        if re.search(pattern, line):
+            if line.rstrip('\n') != target:
+                new_lines.append(target + '\n')
+                ret['changed'] = True
+            else:
+                new_lines.append(line)
+        else:
+            new_lines.append(line)
+
+
+    if not any(re.search(pattern, line) for line in lines):
+        new_lines.append(target + '\n')
+        changed = True
+
+    with open(os.path.join(sysconf_directory, 'constants.conf'), 'w') as constants:
+        constants.writelines(new_lines)
+
+
+    ### Define zones.conf
+    zones_conf = list()
+
+    # Don't change zones.conf if not asked
+    if not zones:
+        return ret
+
+    for zone in zones:
+        # Validate zone is either global or contains endpoints
+        if zone['_global'] and zone['endpoints']:
+            ret['fail_msg'] = 'Zone \'{}\' cannot be global and contain endpoints.'.format(zone['name'])
+            break
+
+        if zone['_global']:
+            zones_conf.append('object Zone "{}" {{'.format(zone['name']))
+            zones_conf.append('  global = true')
+            zones_conf.append('}')
+            zones_conf.append('')
+        else:
+            # Add endpoints
+            for endpoint in zone['endpoints']:
+                zones_conf.append('object Endpoint "{}" {{'.format(endpoint['cn']))
+                if endpoint['host']:
+                    zones_conf.append('  host = "{}"'.format(endpoint['host']))
+                if endpoint['port']:
+                    zones_conf.append('  port = "{}"'.format(endpoint['port']))
+                zones_conf.append('}')
+                zones_conf.append('')
+
+            # Add zone
+            zones_conf.append('object Zone "{}" {{'.format(zone['name']))
+            zones_conf.append('  endpoints = [')
+            for endpoint in zone['endpoints']:
+                zones_conf.append('    "{}",'.format(endpoint['cn']))
+            zones_conf.append('  ]')
+            if zone['parent']:
+                zones_conf.append('  parent = "{}"'.format(zone['parent']))
+            zones_conf.append('}')
+            zones_conf.append('')
+    new_zones = '\n'.join(zones_conf)
+
+    current_zones = ""
+    if os.path.isfile(os.path.join(sysconf_directory, 'zones.conf')):
+        with open(os.path.join(sysconf_directory, 'zones.conf'), 'r') as zones_file:
+            current_zones = zones_file.read()
+
+    if new_zones != current_zones:
+        with open(os.path.join(sysconf_directory, 'zones.conf'), 'w') as zones_file:
+            zones_file.write(new_zones)
+            ret['changed'] = True
+
+    # Enable feature
+    if enable_feature:
+        cmd = [
+            'icinga2',
+            'feature',
+            'enable',
+            'api',
+        ]
+        rc, stdout, stderr = module.run_command(
+            cmd,
+            executable=None,
+            use_unsafe_shell=False,
+            encoding=None,
+            data=None,
+            binary_data=True,
+            expand_user_and_vars=True,
+        )
+        if 'Enabling feature api.' in stdout.decode():
+            ret['changed'] = True
+        elif rc != 0:
+            ret['fail_msg'] = stdout.decode().strip()
+
+    return ret
+
+
+def master_setup(module, cn, ca_directory, certs_directory, force_new_ca=False):
+    ret = dict(
+        changed = False,
+    )
+
+    ### Generate CA
+    cmd = [
+        'icinga2',
+        'pki',
+        'new-ca',
+    ]
+
+    if force_new_ca:
+        os.remove(os.path.join(ca_directory, 'ca.key'))
+        os.remove(os.path.join(ca_directory, 'ca.crt'))
+        os.remove(os.path.join(certs_directory, 'ca.crt'))
+
+    if not glob.glob(os.path.join(ca_directory, 'ca.key')):
+        rc, stdout, stderr = module.run_command(
+            cmd,
+            executable=None,
+            use_unsafe_shell=False,
+            encoding=None,
+            data=None,
+            binary_data=True,
+            expand_user_and_vars=True,
+        )
+        if 'information/base: Writing private key to \'{}\''.format(os.path.join(ca_directory, 'ca.key')) in str(stdout):
+            ret['changed'] = True
+        elif 'critical/cli: Please re-run this command as a privileged user' in str(stdout):
+            ret['fail_msg'] = 'This module has to be run as a privileged user or as the \'nagios\' user.'
+    elif not glob.glob(os.path.join(ca_directory, 'ca.crt')):
+        module.warn(
+            '{} is already present while {} is missing. Not generating a new CA.'.format(
+                os.path.join(ca_directory, 'ca.key'),
+                os.path.join(ca_directory, 'ca.crt')
+            )
+        )
+
+    # Ensure '/var/lib/icinga2/certs/ca.crt' is up to date since this will be returned upon an agent's request (pki request)
+    if not glob.glob(os.path.join(certs_directory, 'ca.crt')) or not filecmp.cmp(os.path.join(ca_directory, 'ca.crt'), os.path.join(certs_directory, 'ca.crt')):
+        shutil.copy(
+            os.path.join(ca_directory, 'ca.crt'),
+            os.path.join(certs_directory, 'ca.crt')
+        )
+
+    # Sign own CSR
+    if not verify_cert(module, os.path.join(ca_directory, 'ca.crt'), os.path.join(certs_directory, cn + '.crt')):
+        cmd = [
+            'icinga2',
+            'pki',
+            'sign-csr',
+            '--csr', os.path.join(certs_directory, cn + '.csr'),
+            '--cert', os.path.join(certs_directory, cn + '.crt'),
+        ]
+        rc, stdout, stderr = module.run_command(
+            cmd,
+            executable=None,
+            use_unsafe_shell=False,
+            encoding=None,
+            data=None,
+            binary_data=True,
+            expand_user_and_vars=True,
+        )
+        ret['changed'] = True
+
+    return ret
+
+
+def agent_setup(module, cn, host, port, ticket, fingerprint, ignore_fingerprint, certs_directory, force_new_cert=False):
+    ret = dict(
+        changed = False,
+    )
+
+    ### Get parent certificate
+    cmd = [
+        'icinga2',
+        'pki',
+        'save-cert',
+        '--host', host,
+        '--port', str(port),
+        '--trustedcert', os.path.join(certs_directory, 'trusted-parent.crt'),
+    ]
+    if force_new_cert or not glob.glob(os.path.join(certs_directory, 'trusted-parent.crt')):
+        rc, stdout, stderr= module.run_command(
+            cmd,
+            executable=None,
+            use_unsafe_shell=False,
+            encoding=None,
+            data=None,
+            binary_data=True,
+            expand_user_and_vars=True,
+        )
+        if 'Failed to fetch certificate from host.' in str(stdout):
+            ret['fail_msg'] = stdout.decode().strip()
+            return ret
+        ret['changed'] = True
+
+
+    ### Talk to master
+    # This one also makes the node receive the new certificate once it's signed
+
+    # Potential answers
+    # information/cli: Writing CA certificate to file '/var/lib/icinga2/certs/ca.crt'.
+    # information/cli: Writing signed certificate to file '/var/lib/icinga2/certs/<node_name>.crt'.
+    #   → RC X
+    #   → First connection after certificate is signed
+    #
+    # Could not fetch valid response. Please check the master log.
+    #   → RC X 
+    #   → If parent is available but does not know the own node's endpoint
+    #
+    # The certificates for CN '<node_name>' and its root CA are valid and uptodate. Skipping automated renewal.
+    #   → RC 1
+    #   → Connected normally, after getting valid certificate
+
+    cmd = [
+        'icinga2',
+        'pki',
+        'request',
+        '--host', host,
+        '--port', str(port),
+        '--trustedcert', os.path.join(certs_directory, 'trusted-parent.crt'),
+        '--ca', os.path.join(certs_directory, 'ca.crt'),
+        '--key', os.path.join(certs_directory, cn + '.key'),
+        '--cert', os.path.join(certs_directory, cn + '.crt'),
+    ]
+    if ticket:
+        cmd.extend(['--ticket', ticket])
+
+    # Make new request only if own cert not valid
+    if not verify_cert(module, os.path.join(certs_directory, 'ca.crt'), os.path.join(certs_directory, cn + '.crt')):
+        rc, stdout, stderr = module.run_command(
+            cmd,
+            executable=None,
+            use_unsafe_shell=False,
+            encoding=None,
+            data=None,
+            binary_data=True,
+            expand_user_and_vars=True,
+        )
+        ret['changed'] = True
+
+    # WIP: Trusted parent cert could be wrong at this point because parent might have forcefully created a new cert
+    # critical/cli: Peer certificate does not match trusted certificate.
+
+    # Validate fingerprint
+    present_fingerprint = get_fingerprint(module, os.path.join(certs_directory, 'ca.crt'))
+    if not ignore_fingerprint and fingerprint != present_fingerprint:
+        ret['fail_msg'] = 'CA fingerprint \'{}\' on host did not match provided fingerprint \'{}\'.'.format(
+            present_fingerprint,
+            fingerprint,
+        )
+
+    return ret
+
+
+def main():
+    module = AnsibleModule(
+        supports_check_mode=True,
+        argument_spec=dict(
+            state=dict(default='present', choices=['present', 'absent'], type='str'),
+            mode=dict(default='agent', choices=['agent', 'satellite', 'master', 'config'], type='str'),
+            cn=dict(type='str'),
+            host=dict(default=None, type='str', aliases=['parent_host']),
+            port=dict(default=5665, type='int', aliases=['parent_port']),
+            ticket=dict(default=None, type='str', no_log=True),
+            enable_feature=dict(default=True, type='bool'),
+            zones=dict(
+                default=list(),
+                type='list',
+                elements='dict',
+                options=dict(
+                    name=dict(required=True, type='str'),
+                    _global=dict(default=False, type='bool', aliases=['global']),
+                    parent=dict(default=None, type='str'),
+                    endpoints=dict(
+                        type='list',
+                        elements='dict',
+                        options=dict(
+                            cn=dict(required=True, type='str', aliases=['name']),
+                            host=dict(default=None, type='str'),
+                            port=dict(default=None, type='int'),
+                        ),
+                    ),
+                ),
+                required_if=[
+                    ['global', False, ['endpoints'], False],
+                    ['_global', False, ['endpoints'], False],
+                ],
+            ),
+            force_new_ca=dict(default=False, type='bool'),
+            force_new_cert=dict(default=False, type='bool'),
+            fingerprint=dict(type='str'),
+            ignore_fingerprint=dict(default=False, type='bool'),
+        ),
+        required_if=[
+            ['mode', 'agent', ['host'], False],
+            ['mode', 'satellite', ['host'], False],
+        ]
+    )
+
+    sysconf_directory = '/etc/icinga2'
+    data_directory    = '/var/lib/icinga2'
+    ca_directory      = os.path.join(data_directory, 'ca')
+    certs_directory   = os.path.join(data_directory, 'certs')
+
+    cn             = module.params['cn']
+    mode           = module.params['mode']
+    zones          = module.params['zones']
+    force_new_ca   = module.params['force_new_ca']
+    force_new_cert = module.params['force_new_cert']
+    enable_feature = module.params['enable_feature']
+
+    if not cn:
+        cn = socket.getfqdn()
+
+    if mode == 'agent':
+        host               = module.params['host']
+        port               = module.params['port']
+        ticket             = module.params['ticket']
+        fingerprint        = module.params['fingerprint']
+        ignore_fingerprint = module.params['ignore_fingerprint']
+
+    ret = dict(
+        changed = False,
+    )
+
+    ### Create certs/ if not present
+    if os.path.isdir(data_directory) and not os.path.isdir(os.path.join(certs_directory)):
+        stat_info = os.stat(data_directory)
+        uid = stat_info.st_uid
+        gid = stat_info.st_gid
+        os.mkdir(certs_directory)
+        os.chown(certs_directory, uid, gid)
+        os.chmod(certs_directory, 0o700)
+        ret['changed'] = True
+
+    ### Create private key and certificate
+    if force_new_cert or any(not os.path.isfile(os.path.join(certs_directory, file)) for file in [cn + '.key', cn + '.crt', cn + '.csr']):
+        cmd = [
+            'icinga2',
+            'pki',
+            'new-cert',
+            '--cn', cn,
+            '--key', os.path.join(certs_directory, cn + '.key'),
+            '--cert', os.path.join(certs_directory, cn + '.crt'),
+            '--csr', os.path.join(certs_directory, cn + '.csr'),
+        ]
+        rc, stdout, stderr = module.run_command(
+            cmd,
+            executable=None,
+            use_unsafe_shell=False,
+            encoding=None,
+            data=None,
+            binary_data=True,
+            expand_user_and_vars=True,
+        )
+        ret['changed'] = True
+
+    # Return values for the given mode + config
+    mode_ret = dict()
+    config_ret = dict()
+
+    if mode == 'agent':
+        mode_ret = agent_setup(module, cn, host, port, ticket, fingerprint, ignore_fingerprint, certs_directory, force_new_cert)
+    elif mode == 'master':
+        mode_ret = master_setup(module, cn, ca_directory, certs_directory, force_new_ca)
+
+    config_ret = configure(module, cn, zones, enable_feature, sysconf_directory)
+    module.warn("config ret " + str(config_ret))
+
+    ### Collect information for return values
+    ret.update(get_return_values(module, cn, ca_directory, certs_directory))
+
+    # this one actually creates / pulls ca.crt
+    #icinga2 pki request --host 192.168.122.113 --port 5665 --trustedcert /var/lib/icinga2/certs/trusted-parent.crt --ca /var/lib/icinga2/certs/ca.crt --key /var/lib/icinga2/certs/ansible-ubuntu24.key --cert /var/lib/icinga2/certs/ansible-ubuntu24.crt
+
+
+    # Verify / test
+    # While 
+    # icinga2 pki verify --cert /var/lib/icinga2/certs/ansible-ubuntu24.crt  --cacert /var/lib/icinga2/certs/ca.crt → RC 2
+    # still pending
+
+    # Potential answers
+    # critical/cli: CRITICAL: Certificate with CN 'ansible-ubuntu24' is NOT signed by CA: self-signed certificate (code 18)
+    #   → RC 2
+    #   → Error until certificate is signed
+    #
+
+    # Check if either setup or configuration had changes
+    module.warn("mode" + str(mode_ret))
+    module.warn("config" + str(config_ret))
+    if any(r['changed'] for r in (mode_ret, config_ret) if 'changed' in r):
+        ret['changed'] = True
+
+    # Check if either setup or configuration had failures
+    if 'fail_msg' in mode_ret:
+        module.fail_json(
+            **ret,
+            msg=mode_ret['fail_msg']
+        )
+    elif 'fail_msg' in config_ret:
+        module.fail_json(
+            **ret,
+            msg=config_ret['fail_msg']
+        )
+
+    module.exit_json(
+        **ret,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/icinga2_api.py
+++ b/plugins/modules/icinga2_api.py
@@ -630,7 +630,7 @@ def main():
     if not cn:
         cn = socket.getfqdn()
 
-    if mode == 'agent':
+    if mode in ['agent', 'satellite']:
         host               = module.params['host']
         port               = module.params['port']
         ticket             = module.params['ticket']
@@ -677,7 +677,7 @@ def main():
     mode_ret = dict()
     config_ret = dict()
 
-    if mode == 'agent':
+    if mode in ['agent', 'satellite']:
         mode_ret = agent_setup(module, cn, host, port, ticket, fingerprint, ignore_fingerprint, certs_directory, force_new_cert)
     elif mode == 'master':
         mode_ret = master_setup(module, cn, ca_directory, certs_directory, force_new_ca)

--- a/plugins/modules/icinga2_api.py
+++ b/plugins/modules/icinga2_api.py
@@ -309,6 +309,15 @@ def configure(module, cn, zones, enable_feature, sysconf_directory):
     ret = dict(
         changed = False,
     )
+    # Sort zones by global attribute, parent attribute, and alphabetically by name
+    zones = sorted(
+        zones,
+        key=lambda zone: (
+            zone.get('_global', False),
+            0 if zone.get('parent') is None else 1,
+            zone.get('name')
+        )
+    )
 
     ### Ensure const NodeName is set to given CN
     with open(os.path.join(sysconf_directory, 'constants.conf'), 'r') as constants:
@@ -369,8 +378,7 @@ def configure(module, cn, zones, enable_feature, sysconf_directory):
             # Add zone
             zones_conf.append('object Zone "{}" {{'.format(zone['name']))
             zones_conf.append('  endpoints = [')
-            for endpoint in zone['endpoints']:
-                zones_conf.append('    "{}",'.format(endpoint['cn']))
+            zones_conf.append(',\n'.join('    "{}"'.format(endpoint['cn']) for endpoint in zone["endpoints"]))
             zones_conf.append('  ]')
             if zone['parent']:
                 zones_conf.append('  parent = "{}"'.format(zone['parent']))

--- a/plugins/modules/icinga2_api.py
+++ b/plugins/modules/icinga2_api.py
@@ -511,12 +511,14 @@ def master_setup(module, cn, ca_directory, certs_directory, force_new_ca=False):
     return ret
 
 
-def agent_setup(module, cn, host, port, ticket, fingerprint, ignore_fingerprint, certs_directory, force_new_cert=False):
+def agent_setup(module, cn, host, port, ticket, fingerprint, ignore_fingerprint, certs_directory, force_new_ca=False, force_new_cert=False):
     ret = dict(
         changed = False,
     )
 
     ### Get parent certificate
+    parent_cert_exists = os.path.isfile(os.path.join(certs_directory, 'trusted-parent.crt'))
+
     cmd = [
         'icinga2',
         'pki',
@@ -525,21 +527,35 @@ def agent_setup(module, cn, host, port, ticket, fingerprint, ignore_fingerprint,
         '--port', str(port),
         '--trustedcert', os.path.join(certs_directory, 'trusted-parent.crt'),
     ]
-    # Get parent cert on demand, when missing, or when fingerprint mismatch
-    if force_new_cert or not glob.glob(os.path.join(certs_directory, 'trusted-parent.crt')) or fingerprint != get_fingerprint(module, os.path.join(certs_directory, 'ca.crt')):
-        rc, stdout, stderr= module.run_command(
-            cmd,
-            executable=None,
-            use_unsafe_shell=False,
-            encoding=None,
-            data=None,
-            binary_data=True,
-            expand_user_and_vars=True,
-        )
-        if 'Failed to fetch certificate from host.' in str(stdout):
-            ret['fail_msg'] = stdout.decode().strip()
-            return ret
+
+    rc, stdout, stderr= module.run_command(
+        cmd,
+        executable=None,
+        use_unsafe_shell=False,
+        encoding=None,
+        data=None,
+        binary_data=True,
+        expand_user_and_vars=True,
+    )
+
+    # Consider connection errors okay, if 'trusted-parent.crt' already exists
+    if 'Failed to fetch certificate from host.' in str(stdout) and not parent_cert_exists:
+        ret['fail_msg'] = stdout.decode().strip()
+        return ret
+    elif not parent_cert_exists:
         ret['changed'] = True
+
+    # Validate parent cert against ca if already present
+    if not force_new_ca and os.path.isfile(os.path.join(certs_directory, 'ca.crt')) and not verify_cert(module, os.path.join(certs_directory, 'ca.crt'), os.path.join(certs_directory, 'trusted-parent.crt')):
+        ret['fail_msg'] = ' '.join([
+            'The \'trusted-parent.crt\' is not signed by the CA.',
+            'This could be a man-in-the-middle or the CA might have been recreated.',
+            'If you want to trust the certificate with fingerprint \'{}\', pass \'force_new_ca: true\' to the module call.'.format(
+                get_fingerprint(module, os.path.join(certs_directory, 'trusted-parent.crt')),
+                os.path.join(certs_directory, 'trusted-parent.crt')
+            )
+        ])
+        return ret
 
     ### Talk to master
     # This one also makes the node receive the new certificate once it's signed
@@ -573,7 +589,7 @@ def agent_setup(module, cn, host, port, ticket, fingerprint, ignore_fingerprint,
         cmd.extend(['--ticket', ticket])
 
     # Make new request only if own cert not valid
-    if not verify_cert(module, os.path.join(certs_directory, 'ca.crt'), os.path.join(certs_directory, cn + '.crt')):
+    if force_new_ca or not verify_cert(module, os.path.join(certs_directory, 'ca.crt'), os.path.join(certs_directory, cn + '.crt')):
         rc, stdout, stderr = module.run_command(
             cmd,
             executable=None,
@@ -583,6 +599,9 @@ def agent_setup(module, cn, host, port, ticket, fingerprint, ignore_fingerprint,
             binary_data=True,
             expand_user_and_vars=True,
         )
+        if 'Cannot connect to host' in str(stdout):
+            ret['fail_msg'] = stdout.decode().strip()
+            return ret
         ret['changed'] = True
 
     # Validate fingerprint
@@ -706,7 +725,7 @@ def main():
     config_ret = dict()
 
     if mode in ['agent', 'satellite']:
-        mode_ret = agent_setup(module, cn, host, port, ticket, fingerprint, ignore_fingerprint, certs_directory, force_new_cert)
+        mode_ret = agent_setup(module, cn, host, port, ticket, fingerprint, ignore_fingerprint, certs_directory, force_new_ca, force_new_cert)
     elif mode == 'master':
         mode_ret = master_setup(module, cn, ca_directory, certs_directory, force_new_ca)
 

--- a/plugins/modules/icinga2_api.py
+++ b/plugins/modules/icinga2_api.py
@@ -9,7 +9,7 @@ description:
   - Ensures correct C(NodeName) constant.
   - Manages C(zones.conf).
   - Does not manage the C(ApiListener) object / C(api) feature.
-version_added: WIP
+version_added: 0.5.0
 author: |
   Matthias Döhler <matthias.doehler@netways.de>
 options:
@@ -496,7 +496,8 @@ def agent_setup(module, cn, host, port, ticket, fingerprint, ignore_fingerprint,
         '--port', str(port),
         '--trustedcert', os.path.join(certs_directory, 'trusted-parent.crt'),
     ]
-    if force_new_cert or not glob.glob(os.path.join(certs_directory, 'trusted-parent.crt')):
+    # Get parent cert on demand, when missing, or when fingerprint mismatch
+    if force_new_cert or not glob.glob(os.path.join(certs_directory, 'trusted-parent.crt')) or fingerprint != get_fingerprint(module, os.path.join(certs_directory, 'ca.crt')):
         rc, stdout, stderr= module.run_command(
             cmd,
             executable=None,
@@ -511,19 +512,18 @@ def agent_setup(module, cn, host, port, ticket, fingerprint, ignore_fingerprint,
             return ret
         ret['changed'] = True
 
-
     ### Talk to master
     # This one also makes the node receive the new certificate once it's signed
 
     # Potential answers
     # information/cli: Writing CA certificate to file '/var/lib/icinga2/certs/ca.crt'.
     # information/cli: Writing signed certificate to file '/var/lib/icinga2/certs/<node_name>.crt'.
-    #   → RC X
+    #   → RC 0
     #   → First connection after certificate is signed
     #
     # Could not fetch valid response. Please check the master log.
-    #   → RC X 
-    #   → If parent is available but does not know the own node's endpoint
+    #   → RC 1 
+    #   → If parent is available but does not know the own node's endpoint (child provides valid cert in this case)
     #
     # The certificates for CN '<node_name>' and its root CA are valid and uptodate. Skipping automated renewal.
     #   → RC 1
@@ -556,14 +556,12 @@ def agent_setup(module, cn, host, port, ticket, fingerprint, ignore_fingerprint,
         )
         ret['changed'] = True
 
-    # WIP: Trusted parent cert could be wrong at this point because parent might have forcefully created a new cert
-    # critical/cli: Peer certificate does not match trusted certificate.
-
     # Validate fingerprint
     present_fingerprint = get_fingerprint(module, os.path.join(certs_directory, 'ca.crt'))
     if not ignore_fingerprint and fingerprint != present_fingerprint:
-        ret['fail_msg'] = 'CA fingerprint \'{}\' on host did not match provided fingerprint \'{}\'.'.format(
+        ret['fail_msg'] = 'CA fingerprint \'{}\' on host (path: \'{}\') did not match provided fingerprint \'{}\'.'.format(
             present_fingerprint,
+            os.path.join(certs_directory, 'ca.crt'),
             fingerprint,
         )
 

--- a/plugins/modules/icinga2_api.py
+++ b/plugins/modules/icinga2_api.py
@@ -114,6 +114,10 @@ options:
             description:
               - Defines the endpoint object's C(port) attribute.
             type: int
+          log_duration:
+            description:
+              - Defines the endpoint object's C(log_duration) attribute.
+            type: str
   force_new_ca:
     description:
       - If O(mode=master) and O(force_new_ca=true), enforces the recreation of the CA certificate and key.
@@ -372,6 +376,8 @@ def configure(module, cn, zones, enable_feature, sysconf_directory):
                     zones_conf.append('  host = "{}"'.format(endpoint['host']))
                 if endpoint['port']:
                     zones_conf.append('  port = "{}"'.format(endpoint['port']))
+                if endpoint['log_duration']:
+                    zones_conf.append('  log_duration = {}'.format(endpoint['log_duration']))
                 zones_conf.append('}')
                 zones_conf.append('')
 
@@ -602,6 +608,7 @@ def main():
                             cn=dict(required=True, type='str', aliases=['name']),
                             host=dict(default=None, type='str'),
                             port=dict(default=None, type='int'),
+                            log_duration=dict(default=None, type='str'),
                         ),
                     ),
                 ),

--- a/plugins/modules/icinga2_api.py
+++ b/plugins/modules/icinga2_api.py
@@ -319,9 +319,16 @@ def configure(module, cn, zones, enable_feature, sysconf_directory):
         key=lambda zone: (
             zone.get('_global', False),
             0 if zone.get('parent') is None else 1,
-            zone.get('name')
+            zone.get('cn')
         )
     )
+    # Sort endpoints by cn
+    for i, zone in enumerate(zones):
+        if zone['endpoints']:
+            zones[i]['endpoints'] = sorted(
+                zone['endpoints'],
+                key=lambda endpoint: endpoint['cn']
+            )
 
     ### Ensure const NodeName is set to given CN
     with open(os.path.join(sysconf_directory, 'constants.conf'), 'r') as constants:

--- a/plugins/modules/icinga2_api.py
+++ b/plugins/modules/icinga2_api.py
@@ -239,6 +239,12 @@ cert_fingerprint:
   type: str
   returned: always
   sample: 53f33316caacd4342a12c130e5fa6d7a619565bd730ac58ef98f8b38a7e03e37
+parent_cert_fingerprint:
+  description:
+    - The sha256 fingerprint of the parent host's certificate.
+  type: str
+  returned: always
+  sample: ab497bcf34d3656f86b37805e0c88fa653aa523806060a440997a3ead0368107
 '''
 
 import filecmp
@@ -303,9 +309,11 @@ def get_return_values(module, cn, ca_directory, certs_directory):
         cn = cn,
         ca_fingerprint = None,
         cert_fingerprint = None,
+        parent_cert_fingerprint = None,
     )
     rv['ca_fingerprint'] = get_fingerprint(module, os.path.join(certs_directory, 'ca.crt'))
     rv['cert_fingerprint'] = get_fingerprint(module, os.path.join(certs_directory, cn + '.crt'))
+    rv['parent_cert_fingerprint'] = get_fingerprint(module, os.path.join(certs_directory, 'trusted-parent.crt'))
     return rv
 
 

--- a/roles/icinga2/tasks/deprecations.yml
+++ b/roles/icinga2/tasks/deprecations.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Check for use of deprecated variables
+  ignore_errors: true
+  loop:
+    - name: Check if old 'ca_host' is used in api feature
+      cond: "{{ icinga2_features | selectattr('name', 'eq', 'api') | selectattr('ca_host', 'defined') | length == 0 }}"
+      msg: |
+        The use of 'ca_host' in the api feature is deprecated.
+        Please use 'parent_host' instead.
+
+    - name: Check if old 'ca_host_port' is used in api feature
+      cond: "{{ icinga2_features | selectattr('name', 'eq', 'api') | selectattr('ca_host_port', 'defined') | length == 0 }}"
+      msg: |
+        The use of 'ca_host_port' in the api feature is deprecated.
+        Please use 'parent_port' instead.
+
+    - name: Check if old 'ticket_salt' is used in api feature
+      cond: "{{ icinga2_features | selectattr('name', 'eq', 'api') | selectattr('ticket_salt', 'defined') | length == 0 }}"
+      msg: |
+        The use of 'ticket_salt' in the api feature is deprecated.
+        Please use 'ticket' instead.
+        With the 'netways.icinga.icinga2_ticket' filter plugin and the actual Icinga 2 `TicketSalt` you can create a valid ticket.
+  ansible.builtin.assert:
+    that: item.cond
+    fail_msg: "{{ item.msg }}"

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -3,29 +3,31 @@
 - name: Set api feature facts
   ansible.builtin.set_fact:
     icinga2_cert_name: "{{ icinga2_dict_features.api.cert_name | default(ansible_facts['fqdn']) }}"
-    icinga2_ca_host: "{{ icinga2_dict_features.api.ca_host | default(omit) }}"
-    icinga2_ca_host_port: "{{ icinga2_dict_features.api.ca_host_port | default(omit) }}"
+    icinga2_parent_host: "{{ icinga2_dict_features.api.parent_host | default(icinga2_dict_features.api.ca_host) | default(omit) }}"
+    icinga2_parent_port: "{{ icinga2_dict_features.api.parent_port | default(icinga2_dict_features.api.ca_host_port) | default(omit) }}"
     icinga2_ca_fingerprint: "{{ icinga2_dict_features.api.ca_fingerprint | default(omit) }}"
-    icinga2_force_newcert: "{{ icinga2_dict_features.api.force_newcert | default(false) }}"
-    icinga2_endpoints: "{{ icinga2_dict_features.api.endpoints | default([]) }}"
+    icinga2_force_newca: "{{ icinga2_dict_features.api.force_newca | default(false) }}"
+    icinga2_force_newcert: "{{ icinga2_dict_features.api.force_newcert | default(False) }}"
+    icinga2_endpoints: "{{ icinga2_dict_features.api.endpoints |default([]) }}"
     icinga2_zones: "{{ icinga2_dict_features.api.zones | default([]) }}"
     icinga2_ssl_cert: "{{ icinga2_dict_features.api.ssl_cert | default(omit) }}"
     icinga2_ssl_cacert: "{{ icinga2_dict_features.api.ssl_cacert | default(omit) }}"
     icinga2_ssl_key: "{{ icinga2_dict_features.api.ssl_key | default(omit) }}"
     icinga2_ssl_remote_source: "{{ icinga2_dict_features.api.ssl_remote_source | default(false) }}"
     icinga2_ticket_salt: "{{ icinga2_dict_features.api.ticket_salt | default(omit) }}"
+    icinga2_ticket: "{{ icinga2_dict_features.api.ticket | default(omit) }}"
     icinga2_delegate_pki: "{{ icinga2_dict_features.api.delegate_pki | default(false) }}"
 
 - name: Check if necessary variables are defined
   ansible.builtin.assert:
-    that: ((icinga2_ssl_cacert is defined and icinga2_ssl_cert is defined and icinga2_ssl_key is defined) or (icinga2_ssl_cacert is undefined and icinga2_ssl_cert is undefined and icinga2_ssl_key is undefined and icinga2_ca_host is defined))
-    fail_msg: ca_host is mandatory or ssl_cacert/cert/key have to be set at the same time
+    that: ((icinga2_ssl_cacert is defined and icinga2_ssl_cert is defined and icinga2_ssl_key is defined) or (icinga2_ssl_cacert is undefined and icinga2_ssl_cert is undefined and icinga2_ssl_key is undefined and icinga2_parent_host is defined))
+    fail_msg: parent_host is mandatory or ssl_cacert/cert/key have to be set at the same time
     success_msg: API Feature is configured correctly
 
 - name: Api feature cleanup arguments list
   ansible.builtin.set_fact:
     icinga2_api_listener_args: "{{ icinga2_api_listener_args | default({}) | combine({idx.key: idx.value}) }}"
-  when: idx.key not in ['ca_host', 'ca_host_port', 'cert_name', 'ca_fingerprint', 'force_newcert', 'zones', 'endpoints', 'ssl_cacert', 'ssl_key', 'ssl_cert', 'ssl_remote_source', 'ticket_salt', 'delegate_pki' ]
+  when: idx.key not in ['ca_host', 'parent_host', 'ca_host_port', 'parent_port', 'cert_name', 'ca_fingerprint', 'force_newcert', 'zones', 'endpoints', 'ssl_cacert', 'ssl_key', 'ssl_cert', 'ssl_remote_source', 'ticket_salt', 'ticket', 'delegate_pki' ]
   loop: "{{ icinga2_dict_features.api | dict2items }}"
   loop_control:
     loop_var: idx
@@ -64,23 +66,14 @@
     loop_var: idx
   register: result
 
-- name: Create new CA
-  block:
-    - name: Check ca key already exists
-      ansible.builtin.stat:
-        path: "{{ icinga2_ca_path }}/ca.key"
-      register: icinga2_ca_key_path
-
-    - name: Check ca cert already exists
-      ansible.builtin.stat:
-        path: "{{ icinga2_ca_path }}/ca.crt"
-      register: icinga2_ca_cert_path
-
-    - name: Create CA
-      ansible.builtin.shell: >
-        icinga2 pki new-ca
-      when: not icinga2_ca_cert_path.stat.exists and not icinga2_ca_key_path.stat.exists
-  when: icinga2_ca_host is defined and icinga2_ca_host == 'none'
+- name: Set up master instance
+  when: icinga2_parent_host is defined and icinga2_parent_host == 'none'
+  netways.icinga.icinga2_api:
+    mode: master
+    cn: "{{ icinga2_cert_name }}"
+    enable_feature: false
+    force_new_ca: "{{ icinga2_force_newca }}"
+    force_new_cert: "{{ icinga2_force_newcert }}"
 
 - name: Check cert key already exists
   ansible.builtin.stat:
@@ -92,96 +85,69 @@
     path: "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.crt"
   register: icinga2_ssl_cert_path
 
+- name: Check ca certificate already exists
+  ansible.builtin.stat:
+    path: "{{ icinga2_cert_path }}/ca.crt"
+  register: icinga2_ssl_ca_cert_path
+
 - name: Certificate request
   when:
-    - not icinga2_ssl_cert_path.stat.exists or not icinga2_ssl_key_path.stat.exists or icinga2_force_newcert
     - icinga2_ssl_cacert is not defined
     - not (icinga2_delegate_pki | bool)
   block:
-    - name: Create cert path
-      ansible.builtin.file:
-        path: "{{ icinga2_cert_path }}"
-        state: directory
-        owner: "{{ icinga2_user }}"
-        group: "{{ icinga2_group }}"
-        mode: "0750"
-
-    - name: Save trusted-master.crt
-      ansible.builtin.shell: >-
-        icinga2 pki save-cert
-        --host "{{ icinga2_ca_host }}"
-        --port "{{ icinga2_ca_host_port | default('5665') }}"
-        --trustedcert "{{ icinga2_cert_path }}/trusted-master.crt"
-      when: icinga2_ca_host != 'none'
-      register: _trusted_master_cert
-
     - name: Normalize ca fingerprint
-      ansible.builtin.set_fact:
-        _ca_fingerprint_normalized: "{{ icinga2_ca_fingerprint | upper | replace(':', ' ') }}"
       when: icinga2_ca_fingerprint is defined
-
-    - name: Validate ca certificate fingerprint
-      ansible.builtin.fail:
-        msg: "CA certificate identity not verified. Fingerprint did not match."
-      when:
-        - icinga2_ca_fingerprint is defined
-        - _trusted_master_cert.stdout | regex_search(_ca_fingerprint_normalized, multiline=true) is none
-
-    - name: Generate private and public key
-      ansible.builtin.shell: >-
-        icinga2 pki new-cert
-        --cn "{{ icinga2_cert_name }}"
-        --key "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.key"
-        {% if icinga2_ca_host != 'none' %} --cert "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.crt" {% else %} --csr "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.csr" {%- endif %}
+      ansible.builtin.set_fact:
+        _ca_fingerprint_normalized: "{{ icinga2_ca_fingerprint | lower | replace(':', '') }}"
 
     - name: Delegate ticket request to master
       no_log: "{{ icinga2_no_log | default(icinga_no_log) | default(true) }}"
-      ansible.builtin.shell: icinga2 pki ticket --cn "{{ icinga2_cert_name }}" {% if icinga2_ticket_salt is defined %} --salt "{{ icinga2_ticket_salt }}"{% endif %}
-      delegate_to: "{{ icinga2_delegate_host | default(icinga2_ca_host) }}"
-      register: icinga2_ticket
-      when: icinga2_ca_host != 'none'
+      delegate_to: "{{ icinga2_delegate_host | default(icinga2_parent_host) }}"
+      ignore_unreachable: true
+      when:
+        - icinga2_parent_host != 'none'
+        - icinga2_ticket is not defined
+      changed_when: false
+      ansible.builtin.command: >
+        icinga2 pki ticket
+            --cn "{{ icinga2_cert_name }}"
+            {% if icinga2_ticket_salt is defined %}
+            --salt "{{ icinga2_ticket_salt }}"
+            {% endif %}
+      register: _icinga2_ticket
 
-    - name: Get certificate
-      ansible.builtin.shell: >-
-        icinga2 pki {% if icinga2_ca_host != 'none' %} request
-        --ticket "{{ icinga2_ticket.stdout }}"
-        --host "{{ icinga2_ca_host }}"
-        --port "{{ icinga2_ca_host_port | default('5665') }}"
-        --ca "{{ icinga2_cert_path }}/ca.crt"
-        --key "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.key"
-        --trustedcert "{{ icinga2_cert_path }}/trusted-master.crt"
-        {% else %} sign-csr --csr "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.csr" {%- endif %}
-        --cert "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.crt"
-      notify: check-and-reload-icinga2-service
-
-    - name: Copy CA root certificate
-      ansible.builtin.copy:
-        src: "{{ icinga2_ca_path }}/ca.crt"
-        dest: "{{ icinga2_cert_path }}/ca.crt"
-        owner: "{{ icinga2_user }}"
-        group: "{{ icinga2_group }}"
-        remote_src: yes
-      when: icinga2_ca_host == 'none'
+    - name: Set up agent / satellite
+      when: icinga2_parent_host != 'none'
+      netways.icinga.icinga2_api:
+        mode: agent
+        cn: "{{ icinga2_cert_name }}"
+        host: "{{ icinga2_parent_host }}"
+        port: "{{ icinga2_parent_port | default(omit) }}"
+        enable_feature: false
+        fingerprint: "{{ _ca_fingerprint_normalized | default(omit) }}"
+        ignore_fingerprint: "{{ _ca_fingerprint_normalized | default(false) | ternary(false, true) }}"
+        ticket: "{{ icinga2_ticket | default(_icinga2_ticket.stdout) | default(omit, true) }}"
+        force_new_cert: "{{ icinga2_force_newcert }}"
 
 - name: Delegated certificate bootstrap
   when:
-    - not icinga2_ssl_cert_path.stat.exists or not icinga2_ssl_key_path.stat.exists or icinga2_force_newcert
+    - not icinga2_ssl_cert_path.stat.exists or not icinga2_ssl_key_path.stat.exists or not icinga2_ssl_ca_cert_path.stat.exists or icinga2_force_newcert
     - icinga2_ssl_cacert is not defined
     - icinga2_delegate_pki | bool
-    - icinga2_ca_host != 'none'
+    - icinga2_parent_host != 'none'
   block:
-    - name: Create cert path
-      ansible.builtin.file:
-        path: "{{ icinga2_cert_path }}"
-        state: directory
-        owner: "{{ icinga2_user }}"
-        group: "{{ icinga2_group }}"
-        mode: "0750"
+    - name: Ensure directories and private key / cert
+      netways.icinga.icinga2_api:
+        mode: config
+        cn: "{{ icinga2_cert_name }}"
+        enable_feature: false
+        force_new_ca: "{{ icinga2_force_newca }}"
+        force_new_cert: "{{ icinga2_force_newcert }}"
 
     - name: Fetch CA certificate from delegated host
       ansible.builtin.slurp:
         src: "{{ icinga2_ca_path }}/ca.crt"
-      delegate_to: "{{ icinga2_delegate_host | default(icinga2_ca_host) }}"
+      delegate_to: "{{ icinga2_delegate_host | default(icinga2_parent_host) }}"
       register: _delegated_ca_cert
 
     - name: Save CA certificate
@@ -192,17 +158,10 @@
         group: "{{ icinga2_group }}"
         mode: "0644"
 
-    - name: Generate private and public key
-      ansible.builtin.command: >-
-        icinga2 pki new-cert
-        --cn "{{ icinga2_cert_name }}"
-        --key "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.key"
-        --cert "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.crt"
-
     - name: Delegate ticket request to master
       no_log: "{{ icinga2_no_log | default(icinga_no_log) | default(true) }}"
+      delegate_to: "{{ icinga2_delegate_host | default(icinga2_parent_host) }}"
       ansible.builtin.command: icinga2 pki ticket --cn "{{ icinga2_cert_name }}" {% if icinga2_ticket_salt is defined %} --salt "{{ icinga2_ticket_salt }}"{% endif %}
-      delegate_to: "{{ icinga2_delegate_host | default(icinga2_ca_host) }}"
       register: _icinga2_ticket
 
     - name: Write ticket file

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -128,6 +128,7 @@
         fingerprint: "{{ _ca_fingerprint_normalized | default(omit) }}"
         ignore_fingerprint: "{{ _ca_fingerprint_normalized | default(false) | ternary(false, true) }}"
         ticket: "{{ icinga2_ticket | default(_icinga2_ticket.stdout) | default(omit, true) }}"
+        force_new_ca: "{{ icinga2_force_newca }}"
         force_new_cert: "{{ icinga2_force_newcert }}"
       notify: check-and-reload-icinga2-service
 

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -74,6 +74,7 @@
     enable_feature: false
     force_new_ca: "{{ icinga2_force_newca }}"
     force_new_cert: "{{ icinga2_force_newcert }}"
+  notify: check-and-reload-icinga2-service
 
 - name: Check cert key already exists
   ansible.builtin.stat:
@@ -128,6 +129,7 @@
         ignore_fingerprint: "{{ _ca_fingerprint_normalized | default(false) | ternary(false, true) }}"
         ticket: "{{ icinga2_ticket | default(_icinga2_ticket.stdout) | default(omit, true) }}"
         force_new_cert: "{{ icinga2_force_newcert }}"
+      notify: check-and-reload-icinga2-service
 
 - name: Delegated certificate bootstrap
   when:
@@ -143,6 +145,7 @@
         enable_feature: false
         force_new_ca: "{{ icinga2_force_newca }}"
         force_new_cert: "{{ icinga2_force_newcert }}"
+      notify: check-and-reload-icinga2-service
 
     - name: Fetch CA certificate from delegated host
       ansible.builtin.slurp:

--- a/roles/icinga2/tasks/main.yml
+++ b/roles/icinga2/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 - ansible.builtin.gather_facts:
 
+- name: Check deprecations
+  ansible.builtin.include_tasks: deprecations.yml
+
 - name: Include OS specific vars
   ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:


### PR DESCRIPTION
Add module `netways.icinga.icinga2_api` to handle setting up the node as a master / agent.

Rework api feature tasks to make use of the new module instead of having all logic in tasks.