### PR TITLE
fix(icingaweb2): allow icingadb config settings in argument spec

### DIFF
--- a/changelogs/fragments/icingaweb2_icingadb_config_settings_schema.yml
+++ b/changelogs/fragments/icingaweb2_icingadb_config_settings_schema.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Allow :code:`icingaweb2_modules.icingadb.config.settings` and :code:`icingaweb2_modules.icingadb.config.security.protected_customvars` in the :code:`icingaweb2` role argument spec.

--- a/changelogs/fragments/icingaweb2_icingadb_config_settings_schema.yml
+++ b/changelogs/fragments/icingaweb2_icingadb_config_settings_schema.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Allow :code:`icingaweb2_modules.icingadb.config.settings` and :code:`icingaweb2_modules.icingadb.config.security.protected_customvars` in the :code:`icingaweb2` role argument spec.
+  - Allow :code:`icingaweb2_modules.icingadb.config.settings` in the :code:`icingaweb2` role argument spec.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -49,6 +49,10 @@
             resource: icingadb
           redis:
             tls: '0'
+          settings:
+            acknowledge_expire: "1"
+            acknowledge_expire_time: P1D
+            hostdowntime_all_services: "1"
         redis:
           redis1:
             host: "127.0.0.1"

--- a/roles/icingaweb2/meta/argument_specs.yml
+++ b/roles/icingaweb2/meta/argument_specs.yml
@@ -380,6 +380,21 @@ argument_specs:
                         description:
                           - Sets the module's database resource.
                         type: str
+                  settings:
+                    description:
+                      - Defines the default settings for the module.
+                    type: dict
+                    required: false
+                  security:
+                    description:
+                      - Defines the security settings.
+                    type: dict
+                    options:
+                      protected_customvars:
+                        description:
+                          - Defines variable name patterns. The values of variables that match a given pattern are hidden from the user's view.
+                          - "Example: C(protected_customvars: *pw*,*pass*,community)"
+                        type: str
                   redis:
                     description:
                       - Defines the C(redis) section of the configuration file.

--- a/roles/icingaweb2/meta/argument_specs.yml
+++ b/roles/icingaweb2/meta/argument_specs.yml
@@ -385,16 +385,6 @@ argument_specs:
                       - Defines the default settings for the module.
                     type: dict
                     required: false
-                  security:
-                    description:
-                      - Defines the security settings.
-                    type: dict
-                    options:
-                      protected_customvars:
-                        description:
-                          - Defines variable name patterns. The values of variables that match a given pattern are hidden from the user's view.
-                          - "Example: C(protected_customvars: *pw*,*pass*,community)"
-                        type: str
                   redis:
                     description:
                       - Defines the C(redis) section of the configuration file.


### PR DESCRIPTION
Fixes #466

I also verified it with molecule. When adding the new config to the `converge.yml` without changing `roles/icingaweb2/meta/argument_specs.yml`, molecule verify fails. After updating the argument specs, it's working as expected.