### PR TITLE
Add coarse-grained tags to the icinga2 role

### DIFF
--- a/roles/icinga2/README.md
+++ b/roles/icinga2/README.md
@@ -49,3 +49,22 @@ The role primarily delegates the ticket creation to the [Icinga ca host](https:/
 ```yaml
 icinga2_delegate_host: icinga-master
 ```
+
+### Tags
+
+The role exposes two coarse-grained tags so playbooks can re-run individual phases without rolling out the full role:
+
+| Tag                 | Effect                                              |
+|---------------------|-----------------------------------------------------|
+| `icinga2_install`   | Runs only the package installation                  |
+| `icinga2_configure` | Renders and deploys the full configuration          |
+
+```bash
+ansible-playbook site.yml --tags icinga2_configure
+```
+
+Fact gathering and loading of the OS specific variables are marked `tags: always`, so they run on every tagged invocation and provide the required context (paths, user, group, ...).
+
+Running the role without `--tags` behaves exactly as before: all phases execute in order.
+
+Handlers are triggered via `notify` as soon as a tagged task reports `changed`, so a service reload still fires on, for example, `--tags icinga2_configure`.

--- a/roles/icinga2/tasks/main.yml
+++ b/roles/icinga2/tasks/main.yml
@@ -28,5 +28,3 @@
 
 - name: Manage service
   ansible.builtin.include_tasks: service.yml
-  tags:
-    - icinga2_service

--- a/roles/icinga2/tasks/main.yml
+++ b/roles/icinga2/tasks/main.yml
@@ -17,12 +17,20 @@
   tags: always
 
 - name: Install
-  ansible.builtin.include_tasks: install.yml
+  ansible.builtin.include_tasks:
+    file: install.yml
+    apply:
+      tags:
+        - icinga2_install
   tags:
     - icinga2_install
 
 - name: Configure
-  ansible.builtin.include_tasks: configure.yml
+  ansible.builtin.include_tasks:
+    file: configure.yml
+    apply:
+      tags:
+        - icinga2_configure
   tags:
     - icinga2_configure
 

--- a/roles/icinga2/tasks/main.yml
+++ b/roles/icinga2/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - ansible.builtin.gather_facts:
+  tags: always
 
 - name: Include OS specific vars
   ansible.builtin.include_vars: "{{ lookup('first_found', _params) }}"
@@ -13,12 +14,19 @@
         - default.yml
       paths:
         - "{{ role_path }}/vars"
+  tags: always
 
 - name: Install
   ansible.builtin.include_tasks: install.yml
+  tags:
+    - icinga2_install
 
 - name: Configure
   ansible.builtin.include_tasks: configure.yml
+  tags:
+    - icinga2_configure
 
 - name: Manage service
   ansible.builtin.include_tasks: service.yml
+  tags:
+    - icinga2_service


### PR DESCRIPTION
Expose icinga2_install, icinga2_configure and icinga2_service tags on the top-level includes so playbooks can re-run individual phases without rolling out the full role. Fact gathering and OS-specific variable loading are marked as always so the tagged runs still have the required context.