### PR TITLE
Add Grafana module to Icinga Web role

### DIFF
--- a/changelogs/fragments/icingaweb2_grafana.yml
+++ b/changelogs/fragments/icingaweb2_grafana.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add module `Grafana <https://github.com/NETWAYS/icingaweb2-module-grafana>`__ to Icinga Web.

--- a/doc/role-icingaweb2/module-grafana.md
+++ b/doc/role-icingaweb2/module-grafana.md
@@ -22,10 +22,10 @@ icingaweb2_modules:
       grafana:
         host: grafana.example.org:3000
         protocol: https
-        datasource: icinga-influxdb
         accessmode: iframe
+        defaultdashboard: icinga2-default
+        defaultdashboarduid: ad5bxjg
     graphs:
-      Load:
-        dashboarduid: icinga-load
-        panelId: "1,2,3"
+      load:
+        dashboarduid: ad5pjfp
 ```

--- a/doc/role-icingaweb2/module-grafana.md
+++ b/doc/role-icingaweb2/module-grafana.md
@@ -28,4 +28,5 @@ icingaweb2_modules:
     graphs:
       load:
         dashboarduid: ad5pjfp
+        panelId: "1,2,3"
 ```

--- a/doc/role-icingaweb2/module-grafana.md
+++ b/doc/role-icingaweb2/module-grafana.md
@@ -1,0 +1,31 @@
+# Module Grafana
+
+This module installs and configures the NETWAYS Grafana module for Icinga Web 2.
+It configures the module only. Grafana itself and its data source must be managed separately.
+
+## Requirements
+
+The `icinga-grafana` package is provided by the NETWAYS Extras repository. When managing repositories with the `netways.icinga.repos` role, enable it:
+
+```yaml
+netways_repo_extras: true
+```
+
+## Example
+
+```yaml
+icingaweb2_modules:
+  grafana:
+    enabled: true
+    source: package
+    config:
+      grafana:
+        host: grafana.example.org:3000
+        protocol: https
+        datasource: icinga-influxdb
+        accessmode: iframe
+    graphs:
+      Load:
+        dashboarduid: icinga-load
+        panelId: "1,2,3"
+```

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,6 +3,7 @@
 - name: Converge
   hosts: all
   vars:
+    netways_repo_extras: true
     icingaweb2_modules:
       businessprocess:
         enabled: true
@@ -21,6 +22,19 @@
             url: 127.0.0.1:9000
           ui:
             default_time_range: 6
+      grafana:
+        enabled: true
+        source: package
+        config:
+          grafana:
+            host: grafana.example.org:3000
+            protocol: https
+            datasource: icinga-influxdb
+            accessmode: direct
+        graphs:
+          Load:
+            dashboarduid: icinga-load
+            panelId: "1,2,3"
       director:
         enabled: true
         source: package

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -29,11 +29,13 @@
           grafana:
             host: grafana.example.org:3000
             protocol: https
-            datasource: icinga-influxdb
-            accessmode: direct
+            datasource: influxdb
+            accessmode: iframe
+            defaultdashboard: icinga2-default
+            defaultdashboarduid: ad5bxjg
         graphs:
-          Load:
-            dashboarduid: icinga-load
+          load:
+            dashboarduid: ad5pjfp
             panelId: "1,2,3"
       director:
         enabled: true

--- a/molecule/default/tests/integration/test_grafana.py
+++ b/molecule/default/tests/integration/test_grafana.py
@@ -1,0 +1,22 @@
+def test_grafana_module(host):
+    module_package = host.package("icinga-grafana")
+    module_dir = host.file("/usr/share/icingaweb2/modules/grafana")
+    enabled_module = host.file("/etc/icingaweb2/enabledModules/grafana")
+    config = host.file("/etc/icingaweb2/modules/grafana/config.ini")
+    graphs = host.file("/etc/icingaweb2/modules/grafana/graphs.ini")
+
+    assert module_package.is_installed
+    assert module_dir.is_directory
+    assert enabled_module.linked_to == "/usr/share/icingaweb2/modules/grafana"
+
+    assert config.is_file
+    assert config.contains("[grafana]")
+    assert config.contains('host = "grafana.example.org:3000"')
+    assert config.contains('protocol = "https"')
+    assert config.contains('datasource = "icinga-influxdb"')
+    assert config.contains('accessmode = "direct"')
+
+    assert graphs.is_file
+    assert graphs.contains("[Load]")
+    assert graphs.contains('dashboarduid = "icinga-load"')
+    assert graphs.contains('panelId = "1,2,3"')

--- a/molecule/default/tests/integration/test_grafana.py
+++ b/molecule/default/tests/integration/test_grafana.py
@@ -13,10 +13,12 @@ def test_grafana_module(host):
     assert config.contains("[grafana]")
     assert config.contains('host = "grafana.example.org:3000"')
     assert config.contains('protocol = "https"')
-    assert config.contains('datasource = "icinga-influxdb"')
-    assert config.contains('accessmode = "direct"')
+    assert config.contains('datasource = "influxdb"')
+    assert config.contains('accessmode = "iframe"')
+    assert config.contains('defaultdashboard = "icinga2-default"')
+    assert config.contains('defaultdashboarduid = "ad5bxjg"')
 
     assert graphs.is_file
-    assert graphs.contains("[Load]")
-    assert graphs.contains('dashboarduid = "icinga-load"')
+    assert graphs.contains("[load]")
+    assert graphs.contains('dashboarduid = "ad5pjfp"')
     assert graphs.contains('panelId = "1,2,3"')

--- a/roles/icingaweb2/README.md
+++ b/roles/icingaweb2/README.md
@@ -11,6 +11,7 @@ The role icingaweb2 installs and configures Icinga Web 2 and its modules.
 * [x509](https://github.com/NETWAYS/ansible-collection-icinga/blob/main/doc/role-icingaweb2/module-x509.md)
 * [Kubernetes](https://github.com/NETWAYS/ansible-collection-icinga/blob/main/doc/role-icingaweb2/module-kubernetes.md)
 * [Graphite](https://github.com/NETWAYS/ansible-collection-icinga/blob/main/doc/role-icingaweb2/module-graphite.md)
+* [Grafana](https://github.com/NETWAYS/ansible-collection-icinga/blob/main/doc/role-icingaweb2/module-grafana.md)
 * [Cube](https://github.com/NETWAYS/ansible-collection-icinga/blob/main/doc/role-icingaweb2/module-cube.md)
 * [vSphereDB](https://github.com/NETWAYS/ansible-collection-icinga/blob/main/doc/role-icingaweb2/module-vspheredb.md)
 * [Performance Data Graphs](https://github.com/NETWAYS/ansible-collection-icinga/blob/main/doc/role-icingaweb2/module-perfdatagraphs.md)

--- a/roles/icingaweb2/meta/argument_specs.yml
+++ b/roles/icingaweb2/meta/argument_specs.yml
@@ -606,6 +606,23 @@ argument_specs:
                     description:
                       - The path to the file on the Ansible controller (uses Ansible's search paths).
                     required: true
+          grafana:
+            description:
+              - Configures the Grafana module for Icinga Web 2.
+            type: dict
+            options:
+              enabled: *module_enabled
+              source: *module_source
+              config:
+                description:
+                  - Defines the Grafana module's C(config.ini) configuration file.
+                type: dict
+                required: false
+              graphs:
+                description:
+                  - Defines the graph mappings for the Grafana module's C(graphs.ini).
+                type: dict
+                required: false
           monitoring:
             description:
               - This configures the L(monitoring module, https://icinga.com/docs/icinga-web/latest/modules/monitoring/doc/03-Configuration/).

--- a/roles/icingaweb2/tasks/modules/grafana.yml
+++ b/roles/icingaweb2/tasks/modules/grafana.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Module Grafana | Ensure config directory
+  ansible.builtin.file:
+    state: directory
+    dest: "{{ icingaweb2_modules_config_dir }}/{{ item.key }}"
+    owner: "{{ icingaweb2_httpd_user }}"
+    group: "{{ icingaweb2_group }}"
+    mode: "2770"
+
+- name: Module Grafana | Manage config files
+  ansible.builtin.include_tasks: manage_module_config.yml
+  loop: "{{ _files }}"
+  loop_control:
+    loop_var: _file
+  when: icingaweb2_modules[_module][_file] is defined
+  vars:
+    _module: "{{ item.key }}"
+    _files:
+      - config
+      - graphs

--- a/roles/icingaweb2/vars/main.yml
+++ b/roles/icingaweb2/vars/main.yml
@@ -3,6 +3,7 @@ icingaweb2_module_packages:
   icingadb: icingadb-web
   director: icinga-director
   graphite: icinga-graphite-web
+  grafana: icinga-grafana
   x509: icinga-x509
   businessprocess: icinga-businessprocess
   kubernetes: icinga-kubernetes-web


### PR DESCRIPTION
  Closes #277

  ## Summary

  Adds Grafana module support to the `icingaweb2` role.

  - Installs the NETWAYS `icinga-grafana` package
  - Requires the NETWAYS Extras repository
  - Configures `config.ini` and `graphs.ini`
  - Enables the module through the existing Icinga Web module workflow
  - Adds argument specifications, documentation and a changelog fragment

  ## Testing

  - `ansible-galaxy collection build --force`
  - `molecule test -s default`
    - 25 tests passed
