### PR TITLE
log level can be INFO, not INFORMATION.

### DIFF
--- a/roles/icingaweb2/meta/argument_specs.yml
+++ b/roles/icingaweb2/meta/argument_specs.yml
@@ -178,7 +178,7 @@ argument_specs:
                   - Specifies the logging level.
                 type: str
                 required: true
-                choices: [ ERROR, WARNING, INFORMATION, DEBUG ]
+                choices: [ ERROR, WARNING, INFO, DEBUG ]
               file:
                 description:
                   - Specifies the log file path if O(icingaweb2_config.logging.log=file).


### PR DESCRIPTION
The icingaweb documentation was incorrect at this point. I’ve fixed that. Now this bit needs to be correct too.