### PR TITLE
Add Icinga Web module `fileshipper`

### DIFF
--- a/changelogs/fragments/470_fileshipper.yml
+++ b/changelogs/fragments/470_fileshipper.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Add module `Fileshipper <https://github.com/Icinga/icingaweb2-module-fileshipper/>`__ to Icinga Web."

--- a/doc/role-icingaweb2/module-fileshipper.md
+++ b/doc/role-icingaweb2/module-fileshipper.md
@@ -1,0 +1,44 @@
+## Module Fileshipper
+
+The Icinga Web Fileshipper module provides CSV, JSON, XML and YAML files as an import source for the Icinga Director.
+
+## Configuration
+
+The general module parameter like `enabled` and `source` can be applied here.
+
+For every config file, create a dictionary with sections as keys and the parameters as values. For all parameters please check the [module documentation](https://icinga.com/docs/icinga-director/latest/fileshipper/doc/02-Installation/#setup-base-directory).
+
+To also deploy the files from the Ansible control node, add a `files` key to the given resource (`imports`/`directories`).
+If entries are removed from `files` or if it is omitted, those files will be removed from the managed node.
+If the key `purge_files` is set to `false`, the files will not be deleted. This allows for manual file deployment if necessary.  
+The `files` and `purge_files` keys will be removed from the dictionary before writing the configuration files (redefines `icingaweb2_modules`).
+
+The directories for the files will be created automatically, using the joined path of `{{ icingaweb2_fragments_path }}/fileshipper/<imports|directories>/` and `fileshipper.imports.<some_name>.basedir` / `fileshipper.directories.<some_name>.source` (e.g. `/var/tmp/icingaweb/fileshipper/imports/<some_name>/`).  
+The use of absolute paths within the `imports` `basedir` and the `directories` `source` is **not supported**!
+
+```yaml
+icingaweb2_modules:
+  fileshipper:
+    enabled: true
+    source: package
+    imports:
+      a_bunch_of_files:
+        basedir: bunch_of_files
+        # Deploys 'cmdb.json' and 'firewall_rules.yml' to '/var/tmp/icingaweb2/fileshipper/imports/bunch_of_files/'
+        files:
+          - cmdb.json
+          - firewall_rules.yml
+      some_more_files:
+        basedir: more_files
+        files:
+          - fileshipper-test.csv
+        # Files in '/var/tmp/icingaweb2/fileshipper/imports/more_files/' will not be removed
+        purge_files: false
+    directories:
+      custom_rules:
+        source: custom_rules
+        target: zones.d/director-global/custom_rules
+        extensions: .conf .md
+        files:
+          - custom_icinga_dsl.conf
+```

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -69,6 +69,37 @@
             host: 127.0.0.1
             username: root
             password: root
+      fileshipper:
+        enabled: true
+        source: package
+        imports:
+          a_bunch_of_files:
+            basedir: bunch
+            files:
+              - fileshipper/file_01.yml
+              - fileshipper/file_02.yml
+          a_bunch_of_files_no_purge:
+            basedir: bunch_no_purge
+            files:
+              - fileshipper/file_01.yml
+              - fileshipper/file_02.yml
+            purge_files: false
+        directories:
+          custom_rules:
+            source: custom_rules
+            target: zones.d/director-global/custom_rules
+            extensions: .conf
+            files:
+              - fileshipper/file_03.conf
+              - fileshipper/file_04.conf
+          custom_rules_no_purge:
+            source: custom_rules_no_purge
+            target: zones.d/director-global/custom_rules
+            extensions: .conf
+            files:
+              - fileshipper/file_03.conf
+              - fileshipper/file_04.conf
+            purge_files: false
     icingaweb2_db:
       type: mysql
       name: icingaweb

--- a/molecule/default/files/fileshipper/file_01.yml
+++ b/molecule/default/files/fileshipper/file_01.yml
@@ -1,0 +1,3 @@
+- some
+- yaml
+- list

--- a/molecule/default/files/fileshipper/file_02.yml
+++ b/molecule/default/files/fileshipper/file_02.yml
@@ -1,0 +1,3 @@
+- another
+- yaml
+- list

--- a/molecule/default/files/fileshipper/file_03.conf
+++ b/molecule/default/files/fileshipper/file_03.conf
@@ -1,0 +1,1 @@
+// Some Icinga DSL

--- a/molecule/default/files/fileshipper/file_04.conf
+++ b/molecule/default/files/fileshipper/file_04.conf
@@ -1,0 +1,1 @@
+// Some more Icinga DSL

--- a/molecule/default/tests/integration/test_fileshipper.py
+++ b/molecule/default/tests/integration/test_fileshipper.py
@@ -1,0 +1,62 @@
+def test_icingaweb2_module_fileshipper(host):
+    import textwrap
+
+    # imports.ini
+    imports_conf = host.file('/etc/icingaweb2/modules/fileshipper/imports.ini')
+    print(imports_conf.content_string)
+    assert imports_conf.is_file
+    assert imports_conf.content_string == textwrap.dedent('''
+        [a_bunch_of_files]
+        basedir = "bunch"
+
+        [a_bunch_of_files_no_purge]
+        basedir = "bunch_no_purge"
+    ''')
+    if host.system_info.distribution == 'centos':
+      assert imports_conf.user == 'apache'
+      assert imports_conf.group == 'icingaweb2'
+      assert imports_conf.mode == 0o660
+    if host.system_info.distribution == 'debian':
+      assert imports_conf.user == 'www-data'
+      assert imports_conf.group == 'icingaweb2'
+      assert imports_conf.mode == 0o660
+
+
+    # directories.ini
+    directories_conf = host.file('/etc/icingaweb2/modules/fileshipper/directories.ini')
+    print(directories_conf.content_string)
+    assert directories_conf.is_file
+    assert directories_conf.content_string == textwrap.dedent('''
+        [custom_rules]
+        source = "custom_rules"
+        target = "zones.d/director-global/custom_rules"
+        extensions = ".conf"
+
+        [custom_rules_no_purge]
+        source = "custom_rules_no_purge"
+        target = "zones.d/director-global/custom_rules"
+        extensions = ".conf"
+    ''')
+
+    if host.system_info.distribution == 'centos':
+      assert directories_conf.user == 'apache'
+      assert directories_conf.group == 'icingaweb2'
+      assert directories_conf.mode == 0o660
+    if host.system_info.distribution == 'debian':
+      assert directories_conf.user == 'www-data'
+      assert directories_conf.group == 'icingaweb2'
+      assert directories_conf.mode == 0o660
+
+    # Deployed files
+    for file in [
+        '/var/tmp/icingaweb/fileshipper/imports/bunch/file_01.yml',
+        '/var/tmp/icingaweb/fileshipper/imports/bunch/file_02.yml',
+        '/var/tmp/icingaweb/fileshipper/imports/bunch_no_purge/file_01.yml',
+        '/var/tmp/icingaweb/fileshipper/imports/bunch_no_purge/file_02.yml',
+        '/var/tmp/icingaweb/fileshipper/directories/custom_rules/file_03.conf',
+        '/var/tmp/icingaweb/fileshipper/directories/custom_rules/file_04.conf',
+        '/var/tmp/icingaweb/fileshipper/directories/custom_rules_no_purge/file_03.conf',
+        '/var/tmp/icingaweb/fileshipper/directories/custom_rules_no_purge/file_04.conf',
+    ]:
+        assert host.file(file).is_file
+

--- a/roles/icingaweb2/README.md
+++ b/roles/icingaweb2/README.md
@@ -13,6 +13,7 @@ The role icingaweb2 installs and configures Icinga Web 2 and its modules.
 * [Graphite](https://github.com/NETWAYS/ansible-collection-icinga/blob/main/doc/role-icingaweb2/module-graphite.md)
 * [Cube](https://github.com/NETWAYS/ansible-collection-icinga/blob/main/doc/role-icingaweb2/module-cube.md)
 * [vSphereDB](https://github.com/NETWAYS/ansible-collection-icinga/blob/main/doc/role-icingaweb2/module-vspheredb.md)
+* [Fileshipper](https://github.com/NETWAYS/ansible-collection-icinga/blob/main/doc/role-icingaweb2/module-fileshipper.md)
 * [Performance Data Graphs](https://github.com/NETWAYS/ansible-collection-icinga/blob/main/doc/role-icingaweb2/module-perfdatagraphs.md)
 * [Performance Data Graphs Graphite](https://github.com/NETWAYS/ansible-collection-icinga/blob/main/doc/role-icingaweb2/module-perfdatagraphsgraphite.md)
 * [Performance Data Graphs InfluxDB v1](https://github.com/NETWAYS/ansible-collection-icinga/blob/main/doc/role-icingaweb2/module-perfdatagraphsinfluxdbv1.md)

--- a/roles/icingaweb2/meta/argument_specs.yml
+++ b/roles/icingaweb2/meta/argument_specs.yml
@@ -979,3 +979,30 @@ argument_specs:
                   - "Example: C(icingaweb2_modules.vspheredb.config: { db: { resource: vspheredb_db } })"
                 type: dict
                 required: false
+          fileshipper:
+            description:
+              - This configures the L(Icinga Web Fileshipper module, https://icinga.com/docs/icinga-director/latest/fileshipper/).
+            type: dict
+            options:
+              enabled: *module_enabled
+              source: *module_source
+              imports:
+                description:
+                  - Defines the Fileshipper imports.
+                  - Each key defines a section of the INI configuration. Each subkey defines an option to that section.
+                  - The special O(files) option is a list of strings with each entry pointing to a file to be deployed within O(basedir).
+                    The O(files) option will not be a part of the written configuration.
+                  - The O(basedir) option must not be an absolute path!
+                  - "Example: C(icingaweb2_modules.fileshipper.imports: { some_files: { basedir: some_files, files: [...] } })"
+                type: dict
+                required: false
+              directories:
+                description:
+                  - Defines Fileshipper directories.
+                  - Each key defines a section of the INI configuration. Each subkey defines an option to that section.
+                  - The special O(files) option is a list of strings with each entry pointing to a file to be deployed within O(source).
+                    The O(files) option will not be a part of the written configuration.
+                  - The O(source) option must not be an absolute path!
+                  - "Example: C(icingaweb2_modules.fileshipper.directories: { custom_config: { source: custom, target: zones.d/director-global/custom.conf, extensions: .conf .md, files: [...] } })"
+                type: dict
+                required: false

--- a/roles/icingaweb2/tasks/modules/deploy_fileshipper_files.yml
+++ b/roles/icingaweb2/tasks/modules/deploy_fileshipper_files.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Module Fileshipper | Deploy files
+  loop: "{{ _files }}"
+  loop_control:
+    loop_var: _file
+  ansible.builtin.copy:
+    src: "{{ _file }}"
+    dest: "{{ _dest }}"
+    owner: "{{ icingaweb2_httpd_user }}"
+    group: "{{ icingaweb2_group }}"
+    mode: "0660"
+  register: _fileshipper_files
+
+- name: Module Fileshipper | Collect deployed files' paths
+  ansible.builtin.set_fact:
+    _fileshipper_files_all: "{{ (_fileshipper_files_all | default([])) + (_fileshipper_files.results | map(attribute='dest')) }}"

--- a/roles/icingaweb2/tasks/modules/fileshipper.yml
+++ b/roles/icingaweb2/tasks/modules/fileshipper.yml
@@ -1,0 +1,103 @@
+---
+
+- name: Module Fileshipper | Files
+  vars:
+    _imports_path: "{{ [icingaweb2_fragments_path, 'fileshipper', 'imports'] | path_join }}"
+    _directories_path: "{{ [icingaweb2_fragments_path, 'fileshipper', 'directories'] | path_join }}"
+  block:
+    - name: Module Fileshipper | Create directories - imports
+      loop: "{{ icingaweb2_modules.fileshipper.imports | default({}) | dict2items | map(attribute='value') | list }}"
+      loop_control:
+        loop_var: _import
+      ansible.builtin.file:
+        state: directory
+        path: "{{ [_imports_path, _import.basedir] | path_join }}"
+        owner: "{{ icingaweb2_httpd_user }}"
+        group: "{{ icingaweb2_group }}"
+        mode: "0750"
+
+    - name: Module Fileshipper | Create directories - directories
+      loop: "{{ icingaweb2_modules.fileshipper.directories | default({}) | dict2items | map(attribute='value') | list }}"
+      loop_control:
+        loop_var: _directory
+      ansible.builtin.file:
+        state: directory
+        path: "{{ [_directories_path, _directory.source] | path_join }}"
+        owner: "{{ icingaweb2_httpd_user }}"
+        group: "{{ icingaweb2_group }}"
+        mode: "0750"
+
+    - name: Module Fileshipper | Deploy files - imports
+      loop: "{{ icingaweb2_modules.fileshipper.imports | default({}) | dict2items | map(attribute='value') | list }}"
+      loop_control:
+        loop_var: _import
+      vars:
+        _dest: "{{ [_imports_path, _import.basedir] | path_join }}"
+        _files: "{{ _import.files | default([]) }}"
+      ansible.builtin.include_tasks: deploy_fileshipper_files.yml
+
+    - name: Module Fileshipper | Deploy files - directories
+      loop: "{{ icingaweb2_modules.fileshipper.directories | default({}) | dict2items | map(attribute='value') | list }}"
+      loop_control:
+        loop_var: _directory
+      vars:
+        _dest: "{{ [_directories_path, _directory.source] | path_join }}"
+        _files: "{{ _directory.files | default([]) }}"
+      ansible.builtin.include_tasks: deploy_fileshipper_files.yml
+
+    - name: Module Fileshipper | Find files
+      loop: "{{ (icingaweb2_modules.fileshipper.imports | default({}) | dict2items + icingaweb2_modules.fileshipper.directories | default({}) | dict2items) | map(attribute='value') }}"
+      loop_control:
+        loop_var: _directory
+      # Ignore directory if 'purge_files: false', not removing any files
+      when: _directory.purge_files | default(true)
+      ansible.builtin.find:
+        paths: "{{ [_imports_path if _directory.basedir is defined else _directories_path, _directory.basedir | default(_directory.source)] | path_join }}"
+        recurse: true
+      register: _fileshipper_deployed_files
+
+- name: Module Fileshipper | Remove unmanaged files
+  # Loop over each file path for all already deployed files, ignoring imports/directories with 'purge_files: false'
+  loop: "{{ _fileshipper_deployed_files.results | selectattr('files', 'defined') | selectattr('files', 'ne', []) | map(attribute='files') | flatten | map(attribute='path') | unique | list }}"
+  loop_control:
+    loop_var: _file
+  when: _file not in _fileshipper_files_all | default([])
+  ansible.builtin.file:
+    state: absent
+    path: "{{ _file }}"
+
+- name: Module Fileshipper | Remove 'files'/'purge_files' keys before writing configuration
+  vars:
+    _fileshipper: "{{
+      {
+        'fileshipper': icingaweb2_modules.fileshipper | combine(
+          {
+            'imports': (icingaweb2_modules.fileshipper.imports | default({}) | dict2items | map('combine', {'value': {'files': omit, 'purge_files': omit}}, recursive=true) | items2dict),
+            'directories': (icingaweb2_modules.fileshipper.directories | default({}) | dict2items | map('combine', {'value': {'files': omit, 'purge_files': omit}}, recursive=true) | items2dict)
+          }
+        )
+      }
+    }}"
+    _icingaweb2_modules: "{{ icingaweb2_modules | combine(_fileshipper, recursive=true) }}"
+  ansible.builtin.set_fact:
+    icingaweb2_modules: "{{ _icingaweb2_modules }}"
+
+- name: Module Fileshipper | Ensure config directory
+  ansible.builtin.file:
+    state: directory
+    dest: "{{ icingaweb2_modules_config_dir }}/fileshipper"
+    owner: "{{ icingaweb2_httpd_user }}"
+    group: "{{ icingaweb2_group }}"
+    mode: "2770"
+
+- name: Module Fileshipper | Manage config files
+  ansible.builtin.include_tasks: manage_module_config.yml
+  loop: "{{ _files }}"
+  loop_control:
+    loop_var: _file
+  when: icingaweb2_modules[_module][_file] is defined
+  vars:
+    _module: "{{ item.key }}"
+    _files:
+      - imports
+      - directories

--- a/roles/icingaweb2/vars/main.yml
+++ b/roles/icingaweb2/vars/main.yml
@@ -20,3 +20,4 @@ icingaweb2_module_packages:
   perfdatagraphsprometheus: icingaweb2-module-perfdatagraphs-prometheus
   perfdatagraphselasticsearch: icingaweb2-module-perfdatagraphs-elasticsearch
   sso: icinga-sso-web
+  fileshipper: icinga-fileshipper-web


### PR DESCRIPTION
Adds the `fileshipper` module to the `icingaweb2` role.  
It allows for the installation and configuration of the `fileshipper` module, as well as allowing for file deployment.